### PR TITLE
Remove defaulting of text field to a field that is part of createjs.Text but not DisplayObject

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Module to add accessibility support to createjs",
   "main": "dist/createjs-accessibility.js",
   "scripts": {

--- a/src/RoleObjectFactory.js
+++ b/src/RoleObjectFactory.js
@@ -85,7 +85,6 @@ function createAccessibilityObjectForRole(config) {
   let accessibilityObject;
   switch (role) {
     // roles resulting in AccessibilityObject in alphabetical order by enum entry
-    case ROLES.FOOTER:
     case ROLES.FIGCAPTION:
     case ROLES.FORMAT_TEXT_BOLD:
     case ROLES.FORMAT_TEXT_CODE:

--- a/src/RoleObjects/AccessibilityObject.js
+++ b/src/RoleObjects/AccessibilityObject.js
@@ -41,7 +41,7 @@ export default class AccessibilityObject {
      * string that describes the DisplayObject for the AT
      * @access public
      */
-    this.text = displayObject.text;
+    this.text = undefined;
   }
 
   /**


### PR DESCRIPTION
Also removing a non-existent role that is allowing registering DisplayObjects without a role when that should produce an error.