### PR TITLE
fix(scaling|container): apply stage scaling & canvas style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/AccessibilityTranslator.js
+++ b/src/AccessibilityTranslator.js
@@ -81,10 +81,10 @@ export default class AccessibilityTranslator extends React.Component {
       const bounds = displayObject.getBounds();
       posGlobalSpace = displayObject.localToGlobal(bounds.x, bounds.y);
       const lowerRight = displayObject.localToGlobal(bounds.x + bounds.width, bounds.y + bounds.height);
-      posParentSpace.x = posGlobalSpace.x - parentBoundsInGlobalSpace.x;
-      posParentSpace.y = posGlobalSpace.y - parentBoundsInGlobalSpace.y;
-      posParentSpace.width = lowerRight.x - posGlobalSpace.x;
-      posParentSpace.height = lowerRight.y - posGlobalSpace.y;
+      posParentSpace.x = (posGlobalSpace.x - parentBoundsInGlobalSpace.x) * (1 / displayObject.stage.scaleX);
+      posParentSpace.y = (posGlobalSpace.y - parentBoundsInGlobalSpace.y) * (1 / displayObject.stage.scaleY);
+      posParentSpace.width = (lowerRight.x - posGlobalSpace.x) * (1 / displayObject.stage.scaleX);
+      posParentSpace.height = (lowerRight.y - posGlobalSpace.y) * (1 / displayObject.stage.scaleY);
     } catch (err) {
       // ignore, this is mainly for the case of undefined bounds
     }

--- a/src/index.js
+++ b/src/index.js
@@ -15,34 +15,31 @@ function positionElemUnderStage(stage, getComponentRef) {
 
   const canvas = stage.canvas;
 
-  const canvasStyle = getComputedStyle(canvas);
+  const {
+    height,
+    width,
+    border,
+    boxSizing,
+    margin,
+    padding,
+    transform,
+    transformOrigin } = getComputedStyle(canvas);
 
-  const canvasCss = {
-    border: canvasStyle['border'],
-    boxSizing: canvasStyle['box-sizing'],
-    marginLeft: canvasStyle['margin-left'],
-    marginTop: canvasStyle['margin-top'],
-    paddingLeft: canvasStyle['padding-left'],
-  };
-
-  const canvasDimensions = {
-    height: canvas.getAttribute('height'),
-    width: canvas.getAttribute('width'),
-  };
-  if (canvasDimensions.height.indexOf('px') === -1) {
-    canvasDimensions.height = `${canvasDimensions.height}px`;
-  }
-  if (canvasDimensions.width.indexOf('px') === -1) {
-    canvasDimensions.width = `${canvasDimensions.width}px`;
-  }
-
-  const moduleStyle = _.merge({
+  const moduleStyle = {
     overflow: 'hidden',
     position: 'absolute',
     left: debugPos ? canvas.offsetLeft + parseInt(canvas.getAttribute('width')) : 'auto',
     top: canvas.offsetTop,
     zIndex: debugPos ? 'auto' : -1,
-  }, canvasCss, canvasDimensions);
+    height,
+    width,
+    border,
+    boxSizing,
+    margin,
+    padding,
+    transform,
+    transformOrigin,
+  };
 
   return (
     <div style={moduleStyle}>


### PR DESCRIPTION
* Update `AccessibilityTranslator` to respect the current Stage `scaleX` and `scaleY`.
* Update `positionElemUnderStage` to use the computed style of the canvas element as the deterministic values for positioning and dimensions.