### PR TITLE
Handle negative width and height

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Module to add accessibility support to createjs",
   "main": "dist/createjs-accessibility.js",
   "scripts": {

--- a/src/AccessibilityTranslator.js
+++ b/src/AccessibilityTranslator.js
@@ -85,6 +85,14 @@ export default class AccessibilityTranslator extends React.Component {
       posParentSpace.y = (posGlobalSpace.y - parentBoundsInGlobalSpace.y) * (1 / displayObject.stage.scaleY);
       posParentSpace.width = (lowerRight.x - posGlobalSpace.x) * (1 / displayObject.stage.scaleX);
       posParentSpace.height = (lowerRight.y - posGlobalSpace.y) * (1 / displayObject.stage.scaleY);
+      if (posParentSpace.width < 0) {
+        posParentSpace.width = -posParentSpace.width;
+        posParentSpace.x -= posParentSpace.width;
+      }
+      if (posParentSpace.height < 0) {
+        posParentSpace.height = -posParentSpace.height;
+        posParentSpace.y -= posParentSpace.height;
+      }
     } catch (err) {
       // ignore, this is mainly for the case of undefined bounds
     }


### PR DESCRIPTION
Since DOM elements should have non-negative width and height but those values can be negative with the coordinate transforms that CAM does from the canvas side, adjusting the post-coordinate transform values of width and height to ensure they are non-negative and adjusting the position accordingly so the DOM element is positioned in the same screen location as the corresponding DisplayObject.