### PR TITLE
Enabling element before the next render pass when it's annotated as enabled and is currently disabled in the DOM so that focus can be put on it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Module to add accessibility support to createjs",
   "main": "dist/createjs-accessibility.js",
   "scripts": {

--- a/src/RoleObjects/AccessibilityObject.js
+++ b/src/RoleObjects/AccessibilityObject.js
@@ -120,9 +120,15 @@ export default class AccessibilityObject {
   requestFocus() {
     const elem = document.getElementById(this._domId);
     if (elem) {
-      if (getComputedStyle(elem).display === 'none') {
+      // handle elements that won't be visible until the next render pass
+      if (this.visibleWithInference && getComputedStyle(elem).display === 'none') {
         this._forceShow();
       }
+      // handle elements that won't be enabled until the next render pass
+      if (this.enabled && elem.getAttribute('disabled') !== null) {
+        elem.removeAttribute('disabled');
+      }
+
       elem.focus();
     }
   }


### PR DESCRIPTION
Also adjusting the visible logic to check that it is annotated as visible before forcing it visible.