### PR TITLE
Grid arrowkey fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "1.0.0-prerelease.6",
+  "version": "1.0.0-prerelease.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@curriculumassociates/createjs-accessibility",
   "version": "1.0.0-prerelease.6",
   "description": "Module to add accessibility support to createjs",
-  "main": "dist/createjs-accessibility.js",
+  "main": "src/index.js",
   "scripts": {
     "build": "rm -rf dist && NODE_ENV=production webpack",
     "lint": "eslint --color src",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "1.0.0-prerelease.6",
+  "version": "1.0.0-prerelease.7",
   "description": "Module to add accessibility support to createjs",
   "main": "dist/createjs-accessibility.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@curriculumassociates/createjs-accessibility",
   "version": "1.0.0-prerelease.6",
   "description": "Module to add accessibility support to createjs",
-  "main": "src/index.js",
+  "main": "dist/createjs-accessibility.js",
   "scripts": {
     "build": "rm -rf dist && NODE_ENV=production webpack",
     "lint": "eslint --color src",

--- a/readme.md
+++ b/readme.md
@@ -102,7 +102,6 @@ Keyboard events on the translated DOM are communicated to the associated Display
 | | keyup | `keyCode`: code for which key was released | A key was released on the keyboard |
 | button | keyboardClick | | clicking event from keyboard interaction |
 | checkbox | keyboardClick | | clicking event from keyboard interaction |
-| grid | keyboardClick | | clicking event from keyboard interaction |
 | menu item | closeMenu | | the menu should close |
 | menu item | openMenu | | the menu should open |
 | menu item | keyboardClick | | the menu item was clicked |
@@ -121,6 +120,7 @@ Keyboard events on the translated DOM are communicated to the associated Display
 | | change | `value`: number representing the new value | the value of the spin button has changed |
 | tab | click | | clicking event from keyboard interaction |
 | tab list | click | | clicking event from keyboard interaction |
+| tree grid | collapseRow | `rowDisplayObject`: DisplayObject for the row to collapse | The specified expandable row of the grid should be collapsed |
 | tree item | click | | clicking event from keyboard interaction |
 
 ### Test app and reference implementation

--- a/readme.md
+++ b/readme.md
@@ -109,7 +109,6 @@ Keyboard events on the translated DOM are communicated to the associated Display
 | | selectionChanged | `selectionStart`: index into the value where the section starts<br>`selectionEnd` index into the value where the section ends<br>`selectionDirection`: "forward" for the selection increasing towards the end of the string, "backward" for the section increasing towards the beginning of the string | there has been a change in which part of the text is selected |
 | multi-select listbox | valueChanged | `selectedValues`: array where each entry is the value of selected options in the listbox<br>`selectedDisplayObjects`: array containing the DisplayObjects that are selected in the listbox | which items are selected in the listbox have changed |
 | radio | keyboardClick | | clicking event from keyboard interaction |
-| row | keyboardClick | | clicking event from keyboard interaction |
 | scrollbar | scroll | For horizontal scrollbars, `scrollLeft`: value in pixels, for how far the content is scrolled horizontally.<br>Otherwise, `scrollTop`: value, in pixels, for how far the content is scrolled vertically | scrolling the scrollbar |
 | single line textbox | valueChanged | `value`: the new string in the textbox | the string in the textbox has changed |
 | | selectionChanged | `selectionStart`: index into the value where the section starts<br>`selectionEnd` index into the value where the section ends<br>`selectionDirection`: "forward" for the selection increasing towards the end of the string, "backward" for the section increasing towards the beginning of the string | there has been a change in which part of the text is selected |
@@ -121,6 +120,7 @@ Keyboard events on the translated DOM are communicated to the associated Display
 | tab | click | | clicking event from keyboard interaction |
 | tab list | click | | clicking event from keyboard interaction |
 | tree grid | collapseRow | `rowDisplayObject`: DisplayObject for the row to collapse | The specified expandable row of the grid should be collapsed |
+| tree grid | expandRow | `rowDisplayObject`: DisplayObject for the row to collapse | The specified expandable row of the grid should be collapsed |
 | tree item | click | | clicking event from keyboard interaction |
 
 ### Test app and reference implementation

--- a/src/RoleObjectFactory.js
+++ b/src/RoleObjectFactory.js
@@ -48,6 +48,7 @@ import TableHeaderData from './RoleObjects/TableHeaderData';
 import TabListData from './RoleObjects/TabListData';
 import TimerData from './RoleObjects/TimerData';
 import TreeData from './RoleObjects/TreeData';
+import TreeGridData from './RoleObjects/TreeGridData';
 import TreeItemData from './RoleObjects/TreeItemData';
 import ToolBarData from './RoleObjects/ToolBarData';
 
@@ -173,7 +174,6 @@ function createAccessibilityObjectForRole(config) {
       break;
 
     case ROLES.GRID:
-    case ROLES.TREEGRID:
       accessibilityObject = new GridData(displayObject, role, domIdPrefix);
       break;
 
@@ -339,6 +339,10 @@ function createAccessibilityObjectForRole(config) {
 
     case ROLES.TREE:
       accessibilityObject = new TreeData(displayObject, role, domIdPrefix);
+      break;
+
+    case ROLES.TREEGRID:
+      accessibilityObject = new TreeGridData(displayObject, role, domIdPrefix);
       break;
 
     case ROLES.TREEITEM:

--- a/src/RoleObjects/AccessibilityObject.js
+++ b/src/RoleObjects/AccessibilityObject.js
@@ -388,6 +388,16 @@ export default class AccessibilityObject {
   }
 
   /**
+   * Retrieves the DisplayObject that this AccessibilityObject instance provides
+   * accessibility annotation for.
+   * @access public
+   * @returns {createjs.DisplayObject} DisplayObject that this AccessibilityObject annotates
+   */
+  get displayObject() {
+    return this._displayObject;
+  }
+
+  /**
    * Retrieves the value of the id attribute used in the DOM for the DisplayObject's accessibility
    * information
    * @access public

--- a/src/RoleObjects/AccessibilityObject.js
+++ b/src/RoleObjects/AccessibilityObject.js
@@ -812,7 +812,7 @@ export default class AccessibilityObject {
 
   /**
    * Event listener for keydown events
-   * @access private
+   * @access protected
    * @param {SyntheticEvent} evt - React event
    */
   _onKeyDown(evt) {
@@ -829,7 +829,7 @@ export default class AccessibilityObject {
 
   /**
    * Event listener for keyup events
-   * @access private
+   * @access protected
    * @param {SyntheticEvent} evt - React event
    */
   _onKeyUp(evt) {

--- a/src/RoleObjects/AccessibilityObject.js
+++ b/src/RoleObjects/AccessibilityObject.js
@@ -138,6 +138,10 @@ export default class AccessibilityObject {
       if (this.enabled && elem.getAttribute('disabled') !== null) {
         elem.removeAttribute('disabled');
       }
+      // handle elements that won't get tabindex updated until the next render pass
+      if (!_.isUndefined(this.tabIndex) && elem.getAttribute('tabindex') === null) {
+        elem.setAttribute('tabindex', this.tabIndex);
+      }
 
       elem.focus();
     }

--- a/src/RoleObjects/CellData.js
+++ b/src/RoleObjects/CellData.js
@@ -1,10 +1,6 @@
 import SectionData from './SectionData';
 
 export default class CellData extends SectionData {
-  constructor(displayObject, role, domIdPrefix) {
-    super(displayObject, role, domIdPrefix);
-  }
-
   /**
    * Sets an element's column index or position with respect to the total number
    * of columns within a table, grid, or treegrid.
@@ -31,7 +27,7 @@ export default class CellData extends SectionData {
    * @param {Number} val - number of columns spanned by this cell.  undefined to unset the field
    */
   set colspan(val) {
-    this._reactProps['colspan'] = val;
+    this._reactProps.colspan = val;
   }
 
   /**
@@ -40,7 +36,7 @@ export default class CellData extends SectionData {
    * @returns {Number} - number of columns spanned by the cell.  undefined if the field is unset
    */
   get colspan() {
-    return this._reactProps['colspan'];
+    return this._reactProps.colspan;
   }
 
   /**
@@ -69,7 +65,7 @@ export default class CellData extends SectionData {
    * @param {Number} val - number of rows spanned by this cell.  undefined to unset the field
    */
   set rowspan(val) {
-    this._reactProps['rowspan'] = val;
+    this._reactProps.rowspan = val;
   }
 
   /**
@@ -78,6 +74,6 @@ export default class CellData extends SectionData {
    * @returns {Number} - number of rows spanned by the cell.  undefined if the field is unset
    */
   get rowspan() {
-    return this._reactProps['rowspan'];
+    return this._reactProps.rowspan;
   }
 }

--- a/src/RoleObjects/CellData.js
+++ b/src/RoleObjects/CellData.js
@@ -3,16 +3,13 @@ import SectionData from './SectionData';
 export default class CellData extends SectionData {
   constructor(displayObject, role, domIdPrefix) {
     super(displayObject, role, domIdPrefix);
-    // Setting Default value for colspan and rowspan to 1
-    this.colspan = 1;
-    this.rowspan = 1;
   }
 
   /**
    * Sets an element's column index or position with respect to the total number
    * of columns within a table, grid, or treegrid.
    * @access public
-   * @param {Number} val - Positive number
+   * @param {Number} val - positive number for column index.  undefined to unset the field.
    */
   set colindex(val) {
     this._reactProps['aria-colindex'] = val;
@@ -22,7 +19,7 @@ export default class CellData extends SectionData {
    * Gives an element's column index or position with respect to the total
    * number of columns within a table, grid, or treegrid.
    * @access public
-   * @returns {Number} - Positive number
+   * @returns {Number} - column index.  undefined if the field is unset
    */
   get colindex() {
     return this._reactProps['aria-colindex'];
@@ -30,22 +27,20 @@ export default class CellData extends SectionData {
 
   /**
    * Sets the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
-   * This value must be at least 1 (default) and low enough to avoid overlap with other
-   * cells in the same row
    * @access public
-   * @param {Number} val - number
+   * @param {Number} val - number of columns spanned by this cell.  undefined to unset the field
    */
   set colspan(val) {
-    this._reactProps['aria-colspan'] = val;
+    this._reactProps['colspan'] = val;
   }
 
   /**
    * Gives the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
    * @access public
-   * @returns {Number} - Positive number
+   * @returns {Number} - number of columns spanned by the cell.  undefined if the field is unset
    */
   get colspan() {
-    return this._reactProps['aria-colspan'];
+    return this._reactProps['colspan'];
   }
 
   /**
@@ -70,23 +65,19 @@ export default class CellData extends SectionData {
 
   /**
    * Sets the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
-   * This value must be at least 1 (default) and low enough to avoid overlap
-   * with next cell in the same column.
-   * Setting the value to 0 indicates that the cell or gridcell is to span all
-   * the remaining rows in the row group.
    * @access public
-   * @param {Number} val - Positive number
+   * @param {Number} val - number of rows spanned by this cell.  undefined to unset the field
    */
   set rowspan(val) {
-    this._reactProps['aria-rowspan'] = val;
+    this._reactProps['rowspan'] = val;
   }
 
   /**
    * Gives the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
    * @access public
-   * @returns {Number} - Positive number
+   * @returns {Number} - number of rows spanned by the cell.  undefined if the field is unset
    */
   get rowspan() {
-    return this._reactProps['aria-rowspan'];
+    return this._reactProps['rowspan'];
   }
 }

--- a/src/RoleObjects/GridData.js
+++ b/src/RoleObjects/GridData.js
@@ -172,27 +172,7 @@ export default class GridData extends TableData {
    * focus)
    */
   _updateTargetDataLeft(targetData) {
-    if (targetData.displayObject.accessible.role === ROLES.ROW) {
-      const rowData = targetData.displayObject.accessible;
-      if (!rowData.expanded) {
-        // non-exandable rows move focus to the previous level's row, if there is one
-        // collapsed exandable rows do the same
-      } else {
-        // expanded exandable rows collapse
-        const collapseEvent = new createjs.Event('collapseRow', false, false);
-        collapseEvent.rowDisplayObject = targetData.displayObject;
-        this._displayObject.dispatchEvent(collapseEvent);
-        return false;
-      }
-    } else {
-      targetData.colIndex--;
-
-      // if on the first cell of the row and the row can receive focus,
-      // then focus moves to the row
-      if (targetData.colIndex < 0 && !_.isUndefined(targetData.displayObject.accessible.parent.tabIndex)) { // eslint-disable-line max-len
-        // todo
-      }
-    }
+    targetData.colIndex--;
 
     return true;
   }
@@ -267,8 +247,8 @@ export default class GridData extends TableData {
 
     const rows = this.children[targetData.sectionIndex].accessible.children;
     if (rows[targetData.rowIndex]) {
-      const colArr = rows[targetData.rowIndex].accessible.children;
-      const cellDisplayObject = colArr[targetData.colIndex];
+      const cells = rows[targetData.rowIndex].accessible.children;
+      const cellDisplayObject = cells[targetData.colIndex];
       if (cellDisplayObject) {
         if (!_.isUndefined(cellDisplayObject.accessible.tabIndex)) {
           nextTarget = cellDisplayObject;

--- a/src/RoleObjects/GridData.js
+++ b/src/RoleObjects/GridData.js
@@ -1,6 +1,7 @@
 import KeyCodes from 'keycodes-enum';
 import _ from 'lodash';
 import TableData from './TableData';
+import { ROLES } from '../Roles';
 
 export default class GridData extends TableData {
   constructor(displayObject, role, domIdPrefix) {
@@ -105,7 +106,7 @@ export default class GridData extends TableData {
 
       if (attemptFocusUpdate) {
         const nextTarget = this._findNextTarget(targetData);
-        this._focusToNextTarget(nextTarget, targetData.displayObject, event);
+        this._focusToNextTarget(nextTarget, targetData, event);
       }
     }
   }
@@ -249,10 +250,10 @@ export default class GridData extends TableData {
       const cells = rows[targetData.rowIndex].accessible.children;
       const cellDisplayObject = cells[targetData.colIndex];
       if (cellDisplayObject) {
-        if (!_.isUndefined(cellDisplayObject.accessible.tabIndex)) {
-          nextTarget = cellDisplayObject;
-        } else if (cellDisplayObject.accessible.children.length > 0) {
+        if (cellDisplayObject.accessible.children.length > 0) {
           nextTarget = cellDisplayObject.accessible.children[0];
+        } else if (cellDisplayObject.accessible.role === ROLES.GRIDCELL) {
+          nextTarget = cellDisplayObject;
         }
       }
     }
@@ -268,12 +269,13 @@ export default class GridData extends TableData {
    *
    * @param {?createjs.DisplayObject} nextTarget - DisplayObject to send focus to.
    * null if focus should not be moved.
-   * @param {!createjs.DisplayObject} prevTarget - the DisplayObject that currently
-   * has focus
+   * @param {!TargetData} targetData - target data convering the DisplayObject
+   * that previously had focused and where focus should move to within the grid
    * @param {!SyntheticEvent} evt - React event
    */
-  _focusToNextTarget(nextTarget, prevTarget, evt) {
+  _focusToNextTarget(nextTarget, targetData, evt) {
     if (nextTarget) {
+      const prevTarget = targetData.displayObject;
       nextTarget.accessible.tabIndex = prevTarget.accessible.tabIndex;
       prevTarget.accessible.tabIndex = -1;
       nextTarget.accessible.requestFocus();
@@ -412,4 +414,10 @@ export default class GridData extends TableData {
  * children array for which has focus.  -1 if the cell itself has focus, which
  * should only occur in the case of the cell having a tabIndex set and therefore
  * this child elements should not be focusable.
+ * @property {?Number} currFocusRowIndex - For TreeGridData if rowIndex might
+ * have been changed, the index of the row that contains or is the item that
+ * currently has  focus.  Otherwise, undefined.
+ * @property {?Number} currFocusSectionIndex - For TreeGridData if rowIndex might
+ * have been changed, the index of the section that contains or is the item that
+ * currently has focus.  Otherwise, undefined.
  */

--- a/src/RoleObjects/GridData.js
+++ b/src/RoleObjects/GridData.js
@@ -83,7 +83,7 @@ export default class GridData extends TableData {
 
   _onKeyDown(event) {
     if (this.enableKeyEvents) {
-      super._onKeyDown(evt);
+      super._onKeyDown(event);
     }
 
     const {
@@ -101,13 +101,13 @@ export default class GridData extends TableData {
             targetData.rowIndex--;
             if (targetData.rowIndex < 0 && targetData.sectionIndex > 0) {
               targetData.sectionIndex--;
-              targetData.rowIndex = this.children[targetData.sectionIndex].accessible.children.length - 1;
+              targetData.rowIndex = this.children[targetData.sectionIndex].accessible.children.length - 1; // eslint-disable-line max-len
               rowArr = this.children[targetData.sectionIndex].accessible.children;
             }
             break;
           case KeyCodes.down:
             targetData.rowIndex++;
-            if (targetData.rowIndex >= rowArr.length && targetData.sectionIndex < (this.children.length - 1)) {
+            if (targetData.rowIndex >= rowArr.length && targetData.sectionIndex < (this.children.length - 1)) { // eslint-disable-line max-len
               targetData.sectionIndex++;
               targetData.rowIndex = 0;
               rowArr = this.children[targetData.sectionIndex].accessible.children;
@@ -168,7 +168,7 @@ export default class GridData extends TableData {
               cellChildIndex: -1,
             };
           } else {
-            _.forEach(cellDisplayObject.accessible.children, (cellChildDisplayObject, cellChildIndex) => {
+            _.forEach(cellDisplayObject.accessible.children, (cellChildDisplayObject, cellChildIndex) => { // eslint-disable-line max-len
               if (cellChildDisplayObject.accessible.domId === id) {
                 matchingData = {
                   displayObject: cellChildDisplayObject,

--- a/src/RoleObjects/GridData.js
+++ b/src/RoleObjects/GridData.js
@@ -73,17 +73,26 @@ export default class GridData extends TableData {
     if ([up, down, right, left, home, end].indexOf(event.keyCode) !== -1) {
       const targetData = this._interactiveElemToGridData(event.target);
       if (targetData) {
-        // todo: handle moving between sections
         // todo: handle expandable rows without relying on the non-standard expandedArrow and collapsedArrow fields on the DisplayObject instance
 
-        const rowArr = this.children[targetData.sectionIndex].accessible.children;
+        let rowArr = this.children[targetData.sectionIndex].accessible.children;
 
         switch (event.keyCode) {
           case KeyCodes.up:
             targetData.rowIndex--;
+            if (targetData.rowIndex < 0 && targetData.sectionIndex > 0) {
+              targetData.sectionIndex--;
+              targetData.rowIndex = this.children[targetData.sectionIndex].accessible.children.length - 1;
+              rowArr = this.children[targetData.sectionIndex].accessible.children;
+            }
             break;
           case KeyCodes.down:
             targetData.rowIndex++;
+            if (targetData.rowIndex >= rowArr.length && targetData.sectionIndex < (this.children.length - 1)) {
+              targetData.sectionIndex++;
+              targetData.rowIndex = 0;
+              rowArr = this.children[targetData.sectionIndex].accessible.children;
+            }
             break;
           case KeyCodes.left:
             targetData.colIndex--;

--- a/src/RoleObjects/GridData.js
+++ b/src/RoleObjects/GridData.js
@@ -1,7 +1,6 @@
 import KeyCodes from 'keycodes-enum';
 import _ from 'lodash';
 import TableData from './TableData';
-import { ROLES } from '../Roles';
 
 export default class GridData extends TableData {
   constructor(displayObject, role, domIdPrefix) {

--- a/src/RoleObjects/GridData.js
+++ b/src/RoleObjects/GridData.js
@@ -26,17 +26,16 @@ export default class GridData extends TableData {
   }
 
   /**
-   *  hierarchical level of the grid within other structures
+   * hierarchical level of the grid within other structures
    * @access public
    * @param {Number} val - aria-level is an integer greater than or equal to 1
    */
-
   set level(val) {
     this._reactProps['aria-level'] = val;
   }
 
   /**
-   *  hierarchical level of the grid within other structures
+   * hierarchical level of the grid within other structures
    * @access public
    * @param {Number} val - aria-level is an integer greater than or equal to 1
    */
@@ -45,7 +44,7 @@ export default class GridData extends TableData {
   }
 
   /**
-   *  user may select more then one item from the current grid
+   * user may select more then one item from the current grid
    * @access public
    * @param {boolean} val - aria-multiselectable is set to true, multiple items
    * in the grid can be selected. The default value is false
@@ -179,13 +178,5 @@ export default class GridData extends TableData {
     });
 
     return matchingData;
-  }
-
-  getRowIndex(target) {
-    return Number(target.getAttribute('aria-rowindex'));
-  }
-
-  getColIndex(target) {
-    return Number(target.getAttribute('aria-colindex'));
   }
 }

--- a/src/RoleObjects/GridData.js
+++ b/src/RoleObjects/GridData.js
@@ -5,8 +5,24 @@ import TableData from './TableData';
 export default class GridData extends TableData {
   constructor(displayObject, role, domIdPrefix) {
     super(displayObject, role, domIdPrefix);
-    _.bindAll(this, 'onKeyDown');
-    this._reactProps.onKeyDown = this.onKeyDown;
+    _.bindAll(this, '_onKeyDown');
+    this._reactProps.onKeyDown = this._onKeyDown;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  set enableKeyEvents(enable) {
+    super.enableKeyEvents = enable;
+    // the keydown listener is needed for this role to function per WAI-ARIA practices
+    this._reactProps.onKeyDown = this._onKeyDown;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get enableKeyEvents() {
+    return super.enableKeyEvents;
   }
 
   /**
@@ -66,7 +82,11 @@ export default class GridData extends TableData {
     return this._reactProps['aria-readonly'];
   }
 
-  onKeyDown(event) {
+  _onKeyDown(event) {
+    if (this.enableKeyEvents) {
+      super._onKeyDown(evt);
+    }
+
     const {
       up, down, right, left, home, end,
     } = KeyCodes;

--- a/src/RoleObjects/GridData.js
+++ b/src/RoleObjects/GridData.js
@@ -85,9 +85,12 @@ export default class GridData extends TableData {
   /**
    * @inheritdoc
    */
-  _onKeyDown(event) {
+  _onKeyDown(evt) {
     if (this.enableKeyEvents) {
-      super._onKeyDown(event);
+      super._onKeyDown(evt);
+      if (evt.defaultPrevented) {
+        return;
+      }
     }
 
     const keyToUpdateMap = {
@@ -99,14 +102,14 @@ export default class GridData extends TableData {
       [KeyCodes.end]: '_updateTargetDataEnd',
     };
 
-    const updateFuncName = keyToUpdateMap[event.keyCode];
+    const updateFuncName = keyToUpdateMap[evt.keyCode];
     if (updateFuncName) {
-      const targetData = this._focusableElemToTargetData(event.target);
+      const targetData = this._focusableElemToTargetData(evt.target);
       const attemptFocusUpdate = this[updateFuncName](targetData);
 
       if (attemptFocusUpdate) {
         const nextTarget = this._findNextTarget(targetData);
-        this._focusToNextTarget(nextTarget, targetData, event);
+        this._focusToNextTarget(nextTarget, targetData, evt);
       }
     }
   }

--- a/src/RoleObjects/GridData.js
+++ b/src/RoleObjects/GridData.js
@@ -138,7 +138,7 @@ export default class GridData extends TableData {
   }
 
   /**
-   *Handles updating the target data when the down arrow key is pressed
+   * Handles updating the target data when the down arrow key is pressed
    * @access protected
    *
    * @param {!TargetData} targetData - target data to update/mutate for which

--- a/src/RoleObjects/RowData.js
+++ b/src/RoleObjects/RowData.js
@@ -1,5 +1,3 @@
-import KeyCodes from 'keycodes-enum';
-import _ from 'lodash';
 import GroupData from './GroupData';
 
 export default class RowData extends GroupData {

--- a/src/RoleObjects/RowData.js
+++ b/src/RoleObjects/RowData.js
@@ -3,12 +3,6 @@ import _ from 'lodash';
 import GroupData from './GroupData';
 
 export default class RowData extends GroupData {
-  constructor(displayObject, role, domIdPrefix) {
-    super(displayObject, role, domIdPrefix);
-    _.bindAll(this, 'onKeyDown');
-    this._reactProps.onKeyDown = this.onKeyDown;
-  }
-
   /**
    * Sets an element's column index or position with respect to the total number
    * of columns within a table, grid, or treegrid.
@@ -67,21 +61,5 @@ export default class RowData extends GroupData {
    */
   get level() {
     return this._reactProps['aria-level'];
-  }
-
-  /**
-   * Keydown listener for an row item
-   * @access private
-   * @param {SyntheticEvent} evt - React event
-   */
-  onKeyDown(evt) {
-    if (evt.keyCode === KeyCodes.enter) {
-      const event = new createjs.Event('keyboardClick', false, evt.cancelable);
-      const skipPreventDefault = this._displayObject.dispatchEvent(event);
-      if (!skipPreventDefault) {
-        evt.preventDefault();
-      }
-      evt.stopPropagation();
-    }
   }
 }

--- a/src/RoleObjects/SelectData.js
+++ b/src/RoleObjects/SelectData.js
@@ -2,19 +2,19 @@ import GroupData from './GroupData';
 
 export default class SelectData extends GroupData {
   /**
-    * Sets the orientation
-    * @access public
-    * @param {String} str - "horizontal" for a horizontal slider, "vertical" for a vertical slider
-    */
+   * Sets the orientation
+   * @access public
+   * @param {String} str - "horizontal" for a horizontal slider, "vertical" for a vertical slider
+   */
   set orientation(str) {
     this._reactProps['aria-orientation'] = str;
   }
 
   /**
-    * Retrieves the orientation
-    * @access public
-    * @returns  {String} str "horizontal" for a horizontal slider, "vertical" for a vertical slider
-    */
+   * Retrieves the orientation
+   * @access public
+   * @returns  {String} str "horizontal" for a horizontal slider, "vertical" for a vertical slider
+   */
   get orientation() {
     return this._reactProps['aria-orientation'];
   }

--- a/src/RoleObjects/TreeGridData.js
+++ b/src/RoleObjects/TreeGridData.js
@@ -44,9 +44,15 @@ export default class TreeGridData extends GridData {
     return this._reactProps['aria-required'];
   }
 
+  /**
+   * @inheritdoc
+   */
   _searchRow(id, rowDisplayObject, sectionIndex, rowIndex) {
     let matchingData = null;
 
+    // Since treegrid rows can be expandable, they can receive focus and therefore
+    // need to be checked if they are what currently has focus instead of just
+    // going through the cells.
     if (rowDisplayObject.accessible.domId === id) {
       matchingData = {
         displayObject: rowDisplayObject,

--- a/src/RoleObjects/TreeGridData.js
+++ b/src/RoleObjects/TreeGridData.js
@@ -1,0 +1,45 @@
+import GridData from './GridData';
+
+export default class TreeGridData extends GridData {
+  /**
+   * Sets the orientation
+   * @access public
+   * @param {String} str - "horizontal" for a horizontal tree
+   * "vertical" for a vertical tree
+   * undefined to unset this field
+   */
+  set orientation(str) {
+    this._reactProps['aria-orientation'] = str;
+  }
+
+  /**
+   * Retrieves the orientation
+   * @access public
+   * @returns  {String} str "horizontal" for a horizontal tree
+   * "vertical" for a vertical tree
+   * undefined if the field is unset
+   */
+  get orientation() {
+    return this._reactProps['aria-orientation'];
+  }
+
+  /**
+   * Sets whether user input is required or not
+   * @access public
+   * @param {boolean} value - true if the element is required, false otherwise,
+   * undefined to unset this field
+   */
+  set required(value) {
+    this._reactProps['aria-required'] = value;
+  }
+
+  /**
+   * Retrieves whether user input is required or not
+   * @access public
+   * @returns {boolean} true if the element is required, false otherwise,
+   * undefined if this field is unset
+   */
+  get required() {
+    return this._reactProps['aria-required'];
+  }
+}

--- a/src/RoleObjects/TreeGridData.js
+++ b/src/RoleObjects/TreeGridData.js
@@ -46,6 +46,48 @@ export default class TreeGridData extends GridData {
   }
 
   /**
+   * Finds a row DisplayObject that is previous to the specified one, visible,
+   * and is a minimally higher level conceptually (which means a lower number
+   * for the level property of the corresponding RowData instance)
+   * @access private
+   *
+   * @param {!createjs.DisplayObject} rowDisplayObject - DisplayObject to find
+   * the higher level row relative to
+   * @returns {?TargetData} target data for the higher level visible row's DisplayObject,
+   * null if no match is found
+   */
+  _findPrevRowAtHigherLevel(rowDisplayObject) {
+    let targetData = null;
+
+    const rowLevel = rowDisplayObject.accessible.level;
+    let sectionIndex = _.findIndex(this.children, rowDisplayObject.accessible.parent.displayObject);
+    for (; sectionIndex >= 0 && !targetData; sectionIndex--) {
+      const tableSectionDisplayObject = this.children[sectionIndex];
+      let rowIndex = _.findIndex(tableSectionDisplayObject.accessible.children, rowDisplayObject);
+      if (rowIndex < 0) {
+        rowIndex = tableSectionDisplayObject.accessible.children.length - 1;
+      }
+      const higherLevelRowIndex = _.findLastIndex(
+        tableSectionDisplayObject.accessible.children,
+        testRow => testRow.accessible.visibleWithInference && testRow.accessible.level < rowLevel,
+        rowIndex
+      );
+
+      if (higherLevelRowIndex !== -1) {
+        targetData = {
+          displayObject: tableSectionDisplayObject.accessible.children[higherLevelRowIndex],
+          sectionIndex,
+          rowIndex: higherLevelRowIndex,
+          colIndex: -1,
+          cellChildIndex: -1,
+        };
+      }
+    }
+
+    return targetData;
+  }
+
+  /**
    * @inheritdoc
    */
   _updateTargetDataLeft(targetData) {
@@ -54,20 +96,25 @@ export default class TreeGridData extends GridData {
       if (!rowData.expanded) {
         // non-exandable rows move focus to the previous level's row, if there is one
         // collapsed exandable rows do the same
+
+        const toRow = this._findPrevRowAtHigherLevel(targetData.displayObject);
+        if (toRow) {
+          toRow.displayObject = targetData.displayObject;
+          targetData = toRow;
+        }
       } else {
         // expanded exandable rows collapse
-        const collapseEvent = new createjs.Event('collapseRow', false, false);
-        collapseEvent.rowDisplayObject = targetData.displayObject;
-        this._displayObject.dispatchEvent(collapseEvent);
+        const evt = new createjs.Event('collapseRow', false, false);
+        evt.rowDisplayObject = targetData.displayObject;
+        this._displayObject.dispatchEvent(evt);
         return false;
       }
     } else {
-      targetData.colIndex--;
+      super._updateTargetDataLeft(targetData);
 
-      // if on the first cell of the row and the row can receive focus,
-      // then focus moves to the row
-      if (targetData.colIndex < 0 && !_.isUndefined(targetData.displayObject.accessible.parent.tabIndex)) { // eslint-disable-line max-len
-        // todo
+      // if on the first cell of the row and the row can't receive focus, then focus should not move
+      if (targetData.colIndex < 0 && _.isUndefined(targetData.displayObject.accessible.parent.tabIndex)) { // eslint-disable-line max-len
+        return false;
       }
     }
 
@@ -78,8 +125,25 @@ export default class TreeGridData extends GridData {
    * @inheritdoc
    */
   _updateTargetDataRight(targetData) {
-    // todo
-    return super._updateTargetDataRight(targetData);
+    let allowFocusUpdate = true;
+
+    if (targetData.displayObject.accessible.role === ROLES.ROW) {
+      if (targetData.displayObject.accessible.expanded === false) {
+        // collapsed expandable rows get expanded
+        const evt = new createjs.Event('expandRow', false, false);
+        evt.rowDisplayObject = targetData.displayObject;
+        this._displayObject.dispatchEvent(evt);
+        allowFocusUpdate = false;
+      } else {
+        // non-expandable rows have focus move to their first cell
+        // expanded expandable rows do the same
+        targetData.colIndex = 0;
+      }
+    } else {
+      allowFocusUpdate = super._updateTargetDataRight(targetData);
+    }
+
+    return allowFocusUpdate;
   }
 
   /**
@@ -107,5 +171,22 @@ export default class TreeGridData extends GridData {
     }
 
     return matchingData;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  _findNextTarget(targetData) {
+    let nextTarget = null;
+
+    if (targetData.colIndex === -1) {
+      // allow focus going to a row
+      const rows = this.children[targetData.sectionIndex].accessible.children;
+      nextTarget = rows[targetData.rowIndex];
+    } else {
+      nextTarget = super._findNextTarget(targetData);
+    }
+
+    return nextTarget;
   }
 }

--- a/src/RoleObjects/TreeGridData.js
+++ b/src/RoleObjects/TreeGridData.js
@@ -47,6 +47,43 @@ export default class TreeGridData extends GridData {
   /**
    * @inheritdoc
    */
+  _updateTargetDataLeft(targetData) {
+    if (targetData.displayObject.accessible.role === ROLES.ROW) {
+      const rowData = targetData.displayObject.accessible;
+      if (!rowData.expanded) {
+        // non-exandable rows move focus to the previous level's row, if there is one
+        // collapsed exandable rows do the same
+      } else {
+        // expanded exandable rows collapse
+        const collapseEvent = new createjs.Event('collapseRow', false, false);
+        collapseEvent.rowDisplayObject = targetData.displayObject;
+        this._displayObject.dispatchEvent(collapseEvent);
+        return false;
+      }
+    } else {
+      targetData.colIndex--;
+
+      // if on the first cell of the row and the row can receive focus,
+      // then focus moves to the row
+      if (targetData.colIndex < 0 && !_.isUndefined(targetData.displayObject.accessible.parent.tabIndex)) { // eslint-disable-line max-len
+        // todo
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  _updateTargetDataRight(targetData) {
+    // todo
+    return super._updateTargetDataRight(targetData);
+  }
+
+  /**
+   * @inheritdoc
+   */
   _searchRow(id, rowDisplayObject, sectionIndex, rowIndex) {
     let matchingData = null;
 

--- a/src/RoleObjects/TreeGridData.js
+++ b/src/RoleObjects/TreeGridData.js
@@ -42,4 +42,25 @@ export default class TreeGridData extends GridData {
   get required() {
     return this._reactProps['aria-required'];
   }
+
+  _searchRow(id, rowDisplayObject, sectionIndex, rowIndex) {
+    let matchingData = null;
+
+    if (rowDisplayObject.accessible.domId === id) {
+      matchingData = {
+        displayObject: rowDisplayObject,
+        sectionIndex,
+        rowIndex,
+        colIndex: -1,
+        cellChildIndex: -1,
+      };
+    } else {
+      _.forEach(rowDisplayObject.accessible.children, (cellDisplayObject, colIndex) => {
+        matchingData = this._searchCell(elem, cellDisplayObject, sectionIndex, rowIndex, colIndex);
+        return !matchingData;
+      });
+    }
+
+    return matchingData;
+  }
 }

--- a/src/RoleObjects/TreeGridData.js
+++ b/src/RoleObjects/TreeGridData.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { ROLES } from '../Roles';
 import GridData from './GridData';
 
 export default class TreeGridData extends GridData {

--- a/src/RoleObjects/TreeGridData.js
+++ b/src/RoleObjects/TreeGridData.js
@@ -153,21 +153,23 @@ export default class TreeGridData extends GridData {
     let allowFocusUpdate = true;
 
     if (targetData.displayObject.accessible.role === ROLES.ROW) {
+      let sectionIndex = targetData.sectionIndex;
       let gotoRowIndex = _.findLastIndex(
-        this.children[targetData.sectionIndex].accessible.children,
+        this.children[sectionIndex].accessible.children,
         testRow => !_.isUndefined(testRow.accessible.tabIndex)
           && testRow.accessible.visibleWithInference,
         targetData.rowIndex - 1
       );
-      let sectionIndex;
-      for (sectionIndex = targetData.sectionIndex - 1;
-        sectionIndex >= 0 && gotoRowIndex === -1;
-        sectionIndex--) {
-        gotoRowIndex = _.findLastIndex(
-          this.children[sectionIndex].accessible.children,
-          testRow => !_.isUndefined(testRow.accessible.tabIndex)
-             && testRow.accessible.visibleWithInference
-        );
+      if (gotoRowIndex === -1) {
+        for (sectionIndex = targetData.sectionIndex - 1;
+          sectionIndex >= 0 && gotoRowIndex === -1;
+          sectionIndex--) {
+          gotoRowIndex = _.findLastIndex(
+            this.children[sectionIndex].accessible.children,
+            testRow => !_.isUndefined(testRow.accessible.tabIndex)
+               && testRow.accessible.visibleWithInference
+          );
+        }
       }
       if (gotoRowIndex === -1) {
         allowFocusUpdate = false;
@@ -193,21 +195,23 @@ export default class TreeGridData extends GridData {
     let allowFocusUpdate = true;
 
     if (targetData.displayObject.accessible.role === ROLES.ROW) {
+      let sectionIndex = targetData.sectionIndex;
       let gotoRowIndex = _.findIndex(
-        this.children[targetData.sectionIndex].accessible.children,
+        this.children[sectionIndex].accessible.children,
         testRow => !_.isUndefined(testRow.accessible.tabIndex)
           && testRow.accessible.visibleWithInference,
         targetData.rowIndex + 1
       );
-      let sectionIndex;
-      for (sectionIndex = targetData.sectionIndex + 1;
-        sectionIndex < this.children.length && gotoRowIndex === -1;
-        sectionIndex++) {
-        gotoRowIndex = _.findIndex(
-          this.children[sectionIndex].accessible.children,
-          testRow => !_.isUndefined(testRow.accessible.tabIndex)
-            && testRow.accessible.visibleWithInference
-        );
+      if (gotoRowIndex === -1) {
+        for (sectionIndex = targetData.sectionIndex + 1;
+          sectionIndex < this.children.length && gotoRowIndex === -1;
+          sectionIndex++) {
+          gotoRowIndex = _.findIndex(
+            this.children[sectionIndex].accessible.children,
+            testRow => !_.isUndefined(testRow.accessible.tabIndex)
+              && testRow.accessible.visibleWithInference
+          );
+        }
       }
       if (gotoRowIndex === -1) {
         allowFocusUpdate = false;

--- a/src/RoleObjects/TreeGridData.js
+++ b/src/RoleObjects/TreeGridData.js
@@ -149,6 +149,74 @@ export default class TreeGridData extends GridData {
   /**
    * @inheritdoc
    */
+  _updateTargetDataUp(targetData) {
+    let allowFocusUpdate = true;
+
+    if (targetData.displayObject.accessible.role === ROLES.ROW) {
+      let gotoRowIndex = _.findLastIndex(
+        this.children[targetData.sectionIndex].accessible.children,
+        testRow => !_.isUndefined(testRow.accessible.tabIndex)
+          && testRow.accessible.visibleWithInference,
+        targetData.rowIndex - 1
+      );
+      for (let sectionIndex = targetData.sectionIndex - 1;
+        sectionIndex >= 0 && gotoRowIndex === -1;
+        sectionIndex--) {
+        gotoRowIndex = _.findLastIndex(
+          this.children[sectionIndex].accessible.children,
+          testRow => !_.isUndefined(testRow.accessible.tabIndex)
+             && testRow.accessible.visibleWithInference
+        );
+      }
+      if (gotoRowIndex === -1) {
+        allowFocusUpdate = false;
+      } else {
+        targetData.rowIndex = gotoRowIndex;
+      }
+    } else {
+      allowFocusUpdate = super._updateTargetDataUp(targetData);
+    }
+
+    return allowFocusUpdate;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  _updateTargetDataDown(targetData) {
+    let allowFocusUpdate = true;
+
+    if (targetData.displayObject.accessible.role === ROLES.ROW) {
+      let gotoRowIndex = _.findIndex(
+        this.children[targetData.sectionIndex].accessible.children,
+        testRow => !_.isUndefined(testRow.accessible.tabIndex)
+          && testRow.accessible.visibleWithInference,
+        targetData.rowIndex + 1
+      );
+      for (let sectionIndex = targetData.sectionIndex + 1;
+        sectionIndex < this.children.length && gotoRowIndex === -1;
+        sectionIndex++) {
+        gotoRowIndex = _.findIndex(
+          this.children[sectionIndex].accessible.children,
+          testRow => !_.isUndefined(testRow.accessible.tabIndex)
+            && testRow.accessible.visibleWithInference
+        );
+      }
+      if (gotoRowIndex === -1) {
+        allowFocusUpdate = false;
+      } else {
+        targetData.rowIndex = gotoRowIndex;
+      }
+    } else {
+      allowFocusUpdate = super._updateTargetDataDown(targetData);
+    }
+
+    return allowFocusUpdate;
+  }
+
+  /**
+   * @inheritdoc
+   */
   _searchRow(id, rowDisplayObject, sectionIndex, rowIndex) {
     let matchingData = null;
 

--- a/src/RoleObjects/TreeGridData.js
+++ b/src/RoleObjects/TreeGridData.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import GridData from './GridData';
 
 export default class TreeGridData extends GridData {
@@ -56,7 +57,7 @@ export default class TreeGridData extends GridData {
       };
     } else {
       _.forEach(rowDisplayObject.accessible.children, (cellDisplayObject, colIndex) => {
-        matchingData = this._searchCell(elem, cellDisplayObject, sectionIndex, rowIndex, colIndex);
+        matchingData = this._searchCell(id, cellDisplayObject, sectionIndex, rowIndex, colIndex);
         return !matchingData;
       });
     }


### PR DESCRIPTION
Updating the grid and treegrid roles (since treegrid depends on grid code-wise) to follow WAI-ARIA practices for the various keystrokes that determine how focus moves through a grid or treegrid