### PR TITLE
Final set of fixes and breaking changes for the 1.0 version of CAM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1484,7 +1484,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -3058,7 +3058,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -3115,7 +3115,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -3350,12 +3350,6 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ini": {
-          "version": "1.3.5",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4029,9 +4023,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "inquirer": {
@@ -4715,7 +4709,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -4745,7 +4739,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -5225,7 +5219,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4475,9 +4475,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "1.0.0-prerelease.9",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2043,9 +2043,9 @@
       }
     },
     "elliptic": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -199,9 +199,9 @@
       }
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true
     },
     "acorn-jsx": {
@@ -2591,14 +2591,6 @@
         "acorn": "^6.0.7",
         "acorn-jsx": "^5.0.0",
         "eslint-visitor-keys": "^1.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
-          "dev": true
-        }
       }
     },
     "esprima": {
@@ -6917,6 +6909,12 @@
         "webpack-sources": "^1.0.1"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+          "dev": true
+        },
         "acorn-dynamic-import": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "keycodes-enum": "^0.0.2",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.19",
     "prop-types": "^15.7.2",
     "react": "^16.6.3",
     "react-dom": "^16.6.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "1.0.0-prerelease.9",
+  "version": "1.0.0",
   "description": "Module to add accessibility support to createjs",
   "main": "dist/createjs-accessibility.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -128,8 +128,12 @@ There is an open source companion test app for this module at https://github.com
 
 ## Browsers Compatibility
 Since the canvas tag was introduced in HTML5, an HTML5 compatible browser is required.  While the module is intended to work across HTML5 browsers, the ones currently tested against are:
-* IE11 (with and without Jaws 18)
-* Chrome 71+
+* Chrome 88+
+* ChromeOS 88+ (with and without ChromeVox)
+* Edge 88
+* Firefox 79+ (with and without NVDA 2020.4)
+* IE11 (with and without Jaws 2019)
+* Safari 13.1.3 (with and without VoiceOver)
 
 ## License
 The Createjs Accessibility Module is released under the ISC license.  https://opensource.org/licenses/ISC

--- a/src/AccessibilityTranslator.js
+++ b/src/AccessibilityTranslator.js
@@ -131,7 +131,7 @@ export default class AccessibilityTranslator extends React.Component {
         margin: 0,
         padding: 0,
       },
-    }, displayObject.accessible.reactProps);
+    }, displayObject.accessible._reactProps);
     if ((tagName === 'div' && role !== ROLES.NONE) || role === ROLES.MENUBAR
       || role === ROLES.MENUITEMCHECKBOX || role === ROLES.MENUITEMRADIO
       || role === ROLES.MENU || role === ROLES.MENUITEM || role === ROLES.SWITCH

--- a/src/RoleObjectFactory.js
+++ b/src/RoleObjectFactory.js
@@ -115,7 +115,6 @@ function createAccessibilityObjectForRole(config) {
     case ROLES.FORMAT_TEXT_STRONG:
     case ROLES.FORMAT_TEXT_SUBSCRIPT:
     case ROLES.FORMAT_TEXT_SUPERSCRIPT:
-    case ROLES.FORMAT_TEXT_TIME:
     case ROLES.FORMAT_TEXT_UNDERLINE:
     case ROLES.FORMAT_TEXT_VARIABLE:
     case ROLES.MAIN:
@@ -331,6 +330,7 @@ function createAccessibilityObjectForRole(config) {
       accessibilityObject = new TabListData(displayObject, role, domIdPrefix);
       break;
 
+    case ROLES.FORMAT_TEXT_TIME:
     case ROLES.TIMER:
       accessibilityObject = new TimerData(displayObject, role, domIdPrefix);
       break;

--- a/src/RoleObjects/AccessibilityObject.js
+++ b/src/RoleObjects/AccessibilityObject.js
@@ -720,14 +720,6 @@ export default class AccessibilityObject {
   }
 
   /**
-   * Retrieves the React props for the element translation of this object.
-   * @access package
-   */
-  get reactProps() {
-    return this._reactProps;
-  }
-
-  /**
    * Sets which notifications should be sent for live regions
    * @access public
    * @param {String} str - space separated list of values from https://www.w3.org/TR/wai-aria/states_and_properties#aria-relevant.  undefined if the field is to be cleared

--- a/src/RoleObjects/AccessibilityObject.js
+++ b/src/RoleObjects/AccessibilityObject.js
@@ -15,7 +15,7 @@ export default class AccessibilityObject {
      * Fields with relatively fixed values that should go into the React props for the
      * element translation of this object.  This is done as an object for easy merging
      * with the rest of the props
-     * @access private
+     * @access package
      */
     this._reactProps = {
       key: this._displayObject.id,

--- a/src/RoleObjects/ButtonData.js
+++ b/src/RoleObjects/ButtonData.js
@@ -77,8 +77,8 @@ export default class ButtonData extends AccessibilityObject {
   * @access public
   * @param {boolean} enable - true if autofocus should be enabled, false otherwise
   */
-  set autofocus(enable) {
-    this._reactProps.autofocus = enable ? 'autofocus' : undefined;
+  set autoFocus(enable) {
+    this._reactProps.autoFocus = enable ? 'autofocus' : undefined;
   }
 
   /**
@@ -86,8 +86,8 @@ export default class ButtonData extends AccessibilityObject {
   * @access public
   * @returns {boolean} true if autofocus is enabled, false otherwise
   */
-  get autofocus() {
-    return this._reactProps.autofocus === 'autofocus';
+  get autoFocus() {
+    return this._reactProps.autoFocus === 'autofocus';
   }
 
   /**

--- a/src/RoleObjects/CellData.js
+++ b/src/RoleObjects/CellData.js
@@ -7,7 +7,7 @@ export default class CellData extends SectionData {
    * @access public
    * @param {Number} val - positive number for column index.  undefined to unset the field.
    */
-  set colindex(val) {
+  set colIndex(val) {
     this._reactProps['aria-colindex'] = val;
   }
 
@@ -17,7 +17,7 @@ export default class CellData extends SectionData {
    * @access public
    * @returns {Number} - column index.  undefined if the field is unset
    */
-  get colindex() {
+  get colIndex() {
     return this._reactProps['aria-colindex'];
   }
 
@@ -26,7 +26,7 @@ export default class CellData extends SectionData {
    * @access public
    * @param {Number} val - number of columns spanned by this cell.  undefined to unset the field
    */
-  set colspan(val) {
+  set colSpan(val) {
     this._reactProps.colSpan = val;
   }
 
@@ -35,7 +35,7 @@ export default class CellData extends SectionData {
    * @access public
    * @returns {Number} - number of columns spanned by the cell.  undefined if the field is unset
    */
-  get colspan() {
+  get colSpan() {
     return this._reactProps.colSpan;
   }
 
@@ -45,7 +45,7 @@ export default class CellData extends SectionData {
    * @access public
    * @param {Number} val - Positive number
    */
-  set rowindex(val) {
+  set rowIndex(val) {
     this._reactProps['aria-rowindex'] = val;
   }
 
@@ -55,7 +55,7 @@ export default class CellData extends SectionData {
    * @access public
    * @returns {Number} - Positive number
    */
-  get rowindex() {
+  get rowIndex() {
     return this._reactProps['aria-rowindex'];
   }
 
@@ -64,7 +64,7 @@ export default class CellData extends SectionData {
    * @access public
    * @param {Number} val - number of rows spanned by this cell.  undefined to unset the field
    */
-  set rowspan(val) {
+  set rowSpan(val) {
     this._reactProps.rowSpan = val;
   }
 
@@ -73,7 +73,7 @@ export default class CellData extends SectionData {
    * @access public
    * @returns {Number} - number of rows spanned by the cell.  undefined if the field is unset
    */
-  get rowspan() {
+  get rowSpan() {
     return this._reactProps.rowSpan;
   }
 }

--- a/src/RoleObjects/CheckBoxData.js
+++ b/src/RoleObjects/CheckBoxData.js
@@ -10,11 +10,26 @@ import InputTagData from './InputTagData';
 export default class CheckBoxData extends InputTagData {
   constructor(displayObject, role, domIdPrefix) {
     super(displayObject, role, domIdPrefix);
-    _.bindAll(this, 'onKeyDown', 'onClick');
-    this._reactProps.onChange = this.onClick;
-    this._reactProps.onKeyDown = this.onKeyDown;
+    _.bindAll(this, '_onKeyDown', '_onChange');
+    this._reactProps.onChange = this._onChange;
+    this._reactProps.onKeyDown = this._onKeyDown;
     this._reactProps.type = 'checkbox';
     this._reactProps.checked = false;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  set enableKeyEvents(enable) {
+    super.enableKeyEvents = enable;
+    this._reactProps.onKeyDown = this._onKeyDown;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get enableKeyEvents() {
+    return super.enableKeyEvents;
   }
 
   /**
@@ -35,13 +50,28 @@ export default class CheckBoxData extends InputTagData {
     return this._reactProps.checked;
   }
 
-  onKeyDown(evt) {
+  /**
+   * @inheritdoc
+   */
+  _onKeyDown(evt) {
+    if (this.enableKeyEvents) {
+      super._onKeyDown(evt);
+      if (evt.defaultPrevented) {
+        return;
+      }
+    }
+
     if (evt.keyCode === KeyCodes.enter) {
       this._displayObject.dispatchEvent('keyboardClick');
     }
   }
 
-  onClick() {
+  /**
+   * Event listener for change events
+   * @access protected
+   * @param {SyntheticEvent} evt - React event
+   */
+  _onChange() {
     this._displayObject.dispatchEvent('keyboardClick');
   }
 }

--- a/src/RoleObjects/ComboBoxData.js
+++ b/src/RoleObjects/ComboBoxData.js
@@ -45,8 +45,8 @@ export default class ComboBoxData extends SelectData {
    * @access public
    * @param {boolean} enable - true if autocomplete should be enabled, false otherwise
    */
-  set autocomplete(enable) {
-    this._reactProps.autocomplete = enable ? 'on' : 'off';
+  set autoComplete(enable) {
+    this._reactProps.autoComplete = enable ? 'on' : 'off';
   }
 
   /**
@@ -54,8 +54,8 @@ export default class ComboBoxData extends SelectData {
    * @access public
    * @returns {boolean} true if autocomplete is enabled, false otherwise
    */
-  get autocomplete() {
-    return this._reactProps.autocomplete === 'on';
+  get autoComplete() {
+    return this._reactProps.autoComplete === 'on';
   }
 
   /**

--- a/src/RoleObjects/FormData.js
+++ b/src/RoleObjects/FormData.js
@@ -42,8 +42,8 @@ export default class FormData extends SectionData {
    * @access public
    * @param {boolean} enable - true if autocomplete should be enabled, false otherwise
    */
-  set autocomplete(enable) {
-    this._reactProps.autocomplete = enable ? 'on' : 'off';
+  set autoComplete(enable) {
+    this._reactProps.autoComplete = enable ? 'on' : 'off';
   }
 
   /**
@@ -51,8 +51,8 @@ export default class FormData extends SectionData {
    * @access public
    * @returns {boolean} true if autocomplete is enabled, false otherwise
    */
-  get autocomplete() {
-    return this._reactProps.autocomplete === 'on';
+  get autoComplete() {
+    return this._reactProps.autoComplete === 'on';
   }
 
   /**

--- a/src/RoleObjects/ImgData.js
+++ b/src/RoleObjects/ImgData.js
@@ -43,8 +43,8 @@ export default class ImgData extends SectionData {
    * @access public
    * @param {String} option - the type of crossorigin sharing to be used
    */
-  set crossorigin(option) {
-    this._reactProps.crossorigin = option;
+  set crossOrigin(option) {
+    this._reactProps.crossOrigin = option;
   }
 
   /**
@@ -52,8 +52,8 @@ export default class ImgData extends SectionData {
    * @access public
    * @returns {String} the type of crossoriging sharing, undefined if this field is unset
    */
-  get crossorigin() {
-    return this._reactProps.crossorigin;
+  get crossOrigin() {
+    return this._reactProps.crossOrigin;
   }
 
   /**
@@ -79,7 +79,7 @@ export default class ImgData extends SectionData {
    * @access public
    * @param {Boolean} option - whether or not this image is part of an image map
    */
-  set ismap(option) {
+  set isMap(option) {
     this._reactProps.ismap = option;
   }
 
@@ -89,7 +89,7 @@ export default class ImgData extends SectionData {
    * @returns {Boolean} whether or not this image is part of an image map,
    * undefined if this field is unset
    */
-  get ismap() {
+  get isMap() {
     return this._reactProps.ismap;
   }
 
@@ -98,7 +98,7 @@ export default class ImgData extends SectionData {
    * @access public
    * @param {String} url - a URL to a detailed description of an image
    */
-  set longdesc(url) {
+  set longDesc(url) {
     this._reactProps.longdesc = url;
   }
 
@@ -107,7 +107,7 @@ export default class ImgData extends SectionData {
    * @access public
    * @returns {String} a URL to a detailed description of an image, undefined if this field is unset
    */
-  get longdesc() {
+  get longDesc() {
     return this._reactProps.longdesc;
   }
 
@@ -152,8 +152,8 @@ export default class ImgData extends SectionData {
    * @access public
    * @param {String} url - the URL of an image to use in different situations
    */
-  set srcset(url) {
-    this._reactProps.srcset = url;
+  set srcSet(url) {
+    this._reactProps.srcSet = url;
   }
 
   /**
@@ -162,8 +162,8 @@ export default class ImgData extends SectionData {
    * @returns {String} the URL of an image to use in different situations,
    * undefined if this field is unset
    */
-  get srcset() {
-    return this._reactProps.srcset;
+  get srcSet() {
+    return this._reactProps.srcSet;
   }
 
   /**
@@ -171,8 +171,8 @@ export default class ImgData extends SectionData {
    * @access public
    * @param {String} map - the name of the map to use to make the image a client-side image map
    */
-  set usemap(map) {
-    this._reactProps.usemap = map;
+  set useMap(map) {
+    this._reactProps.useMap = map;
   }
 
   /**
@@ -181,8 +181,8 @@ export default class ImgData extends SectionData {
    * @returns {String} the name of the map to use to make the image a client-side
    * image map, undefined if this field is unset
    */
-  get usemap() {
-    return this._reactProps.usemap;
+  get useMap() {
+    return this._reactProps.useMap;
   }
 
   /**

--- a/src/RoleObjects/InputTagData.js
+++ b/src/RoleObjects/InputTagData.js
@@ -25,8 +25,8 @@ export default class InputTagData extends AccessibilityObject {
    * @access public
    * @param {boolean} enable - true if autofocus should be enabled, false otherwise
    */
-  set autofocus(enable) {
-    this._reactProps.autofocus = enable ? 'autofocus' : undefined;
+  set autoFocus(enable) {
+    this._reactProps.autoFocus = enable ? 'autofocus' : undefined;
   }
 
   /**
@@ -34,8 +34,8 @@ export default class InputTagData extends AccessibilityObject {
    * @access public
    * @returns {boolean} true if autofocus is enabled, false otherwise
    */
-  get autofocus() {
-    return this._reactProps.autofocus === 'autofocus';
+  get autoFocus() {
+    return this._reactProps.autoFocus === 'autofocus';
   }
 
   /**

--- a/src/RoleObjects/LinkData.js
+++ b/src/RoleObjects/LinkData.js
@@ -45,7 +45,7 @@ export default class LinkData extends AccessibilityObject {
    * @access public
    * @param {String} lang - Specifies the language of the text in the linked document
    */
-  set hreflang(lang) {
+  set hrefLang(lang) {
     this._reactProps.hrefLang = lang;
   }
 
@@ -55,7 +55,7 @@ export default class LinkData extends AccessibilityObject {
    * @returns {String} the language of the text in the linked document, undefined
    * if this field is unset
    */
-  get hreflang() {
+  get hrefLang() {
     return this._reactProps.hrefLang;
   }
 

--- a/src/RoleObjects/MenuBarData.js
+++ b/src/RoleObjects/MenuBarData.js
@@ -6,8 +6,23 @@ import SelectData from './SelectData';
 export default class MenuBarData extends SelectData {
   constructor(displayObject, role, domIdPrefix) {
     super(displayObject, role, domIdPrefix);
-    _.bindAll(this, 'onKeyDown');
-    this._reactProps.onKeyDown = this.onKeyDown;
+    _.bindAll(this, '_onKeyDown');
+    this._reactProps.onKeyDown = this._onKeyDown;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  set enableKeyEvents(enable) {
+    super.enableKeyEvents = enable;
+    this._reactProps.onKeyDown = this._onKeyDown;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get enableKeyEvents() {
+    return super.enableKeyEvents;
   }
 
   /**
@@ -33,10 +48,16 @@ export default class MenuBarData extends SelectData {
   }
 
   /**
-   * Listener to use for keydown events
-   * @access package
+   * @inheritdoc
    */
-  onKeyDown(evt) {
+  _onKeyDown(evt) {
+    if (this.enableKeyEvents) {
+      super._onKeyDown(evt);
+      if (evt.defaultPrevented) {
+        return;
+      }
+    }
+
     if (evt.keyCode === KeyCodes.left || evt.keyCode === KeyCodes.right) {
       // close a menu if any are open
       let index = _.findIndex(this._children, menu => menu.accessible.expanded);

--- a/src/RoleObjects/MenuData.js
+++ b/src/RoleObjects/MenuData.js
@@ -6,8 +6,23 @@ import SelectData from './SelectData';
 export default class MenuData extends SelectData {
   constructor(displayObject, role, domIdPrefix) {
     super(displayObject, role, domIdPrefix);
-    _.bindAll(this, 'onKeyDown');
-    this._reactProps.onKeyDown = this.onKeyDown;
+    _.bindAll(this, '_onKeyDown');
+    this._reactProps.onKeyDown = this._onKeyDown;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  set enableKeyEvents(enable) {
+    super.enableKeyEvents = enable;
+    this._reactProps.onKeyDown = this._onKeyDown;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get enableKeyEvents() {
+    return super.enableKeyEvents;
   }
 
   /**
@@ -33,10 +48,16 @@ export default class MenuData extends SelectData {
   }
 
   /**
-   * Listener to use for keydown events
-   * @access package
+   * @inheritdoc
    */
-  onKeyDown(evt) {
+  _onKeyDown(evt) {
+    if (this.enableKeyEvents) {
+      super._onKeyDown(evt);
+      if (evt.defaultPrevented) {
+        return;
+      }
+    }
+
     if (evt.keyCode === KeyCodes.up || evt.keyCode === KeyCodes.down) {
       const targetId = evt.target.id;
       const currIndex = this._domIdToChildIndex(targetId);

--- a/src/RoleObjects/MenuItemData.js
+++ b/src/RoleObjects/MenuItemData.js
@@ -6,11 +6,12 @@ import AccessibilityObject from './AccessibilityObject';
 export default class MenuItemData extends AccessibilityObject {
   constructor(displayObject, role, domIdPrefix) {
     super(displayObject, role, domIdPrefix);
-    _.bindAll(this, '_onKeyDown');
+    _.bindAll(this, '_onKeyDown', '_menuItemKeyDown', '_subMenuOpenerKeyDown');
 
     this._reactProps.onKeyDown = this._onKeyDown;
     this._isPopupOpener = false;
     this._reactProps['aria-haspopup'] = false;
+    this._activeKeyDownListener = this._menuItemKeyDown;
   }
 
   /**
@@ -63,6 +64,7 @@ export default class MenuItemData extends AccessibilityObject {
    */
   set subMenu(displayObject) {
     this._subMenu = displayObject;
+    this._activeKeyDownListener = displayObject ? this._subMenuOpenerKeyDown : this._menuItemKeyDown;
   }
 
   /**
@@ -174,7 +176,7 @@ export default class MenuItemData extends AccessibilityObject {
     if ([ROLES.MENUITEM, ROLES.MENUITEMCHECKBOX].indexOf(displayObject.accessible.role) !== -1) {
       displayObject.accessible._isPopupOpener = true;
       this._label = displayObject;
-      this._reactProps.onKeyDown = undefined; // TODO: investigate
+      this._activeKeyDownListener = undefined;
     } else if (displayObject.accessible.role === ROLES.MENU) {
       this._subMenu = displayObject;
     }
@@ -195,10 +197,8 @@ export default class MenuItemData extends AccessibilityObject {
       }
     }
 
-    if (this._subMenu) {
-      this._subMenuOpenerKeyDown(evt);
-    } else {
-      this._menuItemKeyDown(evt);
+    if (this._activeKeyDownListener) {
+      this._activeKeyDownListener(evt);
     }
   }
 }

--- a/src/RoleObjects/MenuItemData.js
+++ b/src/RoleObjects/MenuItemData.js
@@ -64,7 +64,9 @@ export default class MenuItemData extends AccessibilityObject {
    */
   set subMenu(displayObject) {
     this._subMenu = displayObject;
-    this._activeKeyDownListener = displayObject ? this._subMenuOpenerKeyDown : this._menuItemKeyDown;
+    this._activeKeyDownListener = displayObject
+      ? this._subMenuOpenerKeyDown
+      : this._menuItemKeyDown;
   }
 
   /**

--- a/src/RoleObjects/MultiLineTextBoxData.js
+++ b/src/RoleObjects/MultiLineTextBoxData.js
@@ -62,8 +62,8 @@ export default class MultiLineTextBoxData extends AccessibilityObject {
    * @access public
    * @param {boolean} enable - true if autofocus should be enabled, false otherwise
    */
-  set autofocus(enable) {
-    this._reactProps.autofocus = enable ? 'autofocus' : undefined;
+  set autoFocus(enable) {
+    this._reactProps.autoFocus = enable ? 'autofocus' : undefined;
   }
 
   /**
@@ -71,8 +71,8 @@ export default class MultiLineTextBoxData extends AccessibilityObject {
    * @access public
    * @returns {boolean} true if autofocus is enabled, false otherwise
    */
-  get autofocus() {
-    return this._reactProps.autofocus === 'autofocus';
+  get autoFocus() {
+    return this._reactProps.autoFocus === 'autofocus';
   }
 
   /**

--- a/src/RoleObjects/MultiSelectListBoxData.js
+++ b/src/RoleObjects/MultiSelectListBoxData.js
@@ -35,8 +35,8 @@ export default class MultiSelectListBoxData extends SelectData {
    * @access public
    * @param {boolean} enable - true if autofocus should be enabled, false otherwise
    */
-  set autofocus(enable) {
-    this._reactProps.autofocus = enable ? 'autofocus' : undefined;
+  set autoFocus(enable) {
+    this._reactProps.autoFocus = enable ? 'autofocus' : undefined;
   }
 
   /**
@@ -44,8 +44,8 @@ export default class MultiSelectListBoxData extends SelectData {
    * @access public
    * @returns {boolean} true if autofocus is enabled, false otherwise
    */
-  get autofocus() {
-    return this._reactProps.autofocus === 'autofocus';
+  get autoFocus() {
+    return this._reactProps.autoFocus === 'autofocus';
   }
 
   /**

--- a/src/RoleObjects/RadioData.js
+++ b/src/RoleObjects/RadioData.js
@@ -5,10 +5,25 @@ import InputTagData from './InputTagData';
 export default class RadioData extends InputTagData {
   constructor(displayObject, role, domIdPrefix) {
     super(displayObject, role, domIdPrefix);
-    _.bindAll(this, '_onRadioKeyDown');
+    _.bindAll(this, '_onKeyDown');
     this._reactProps.type = 'radio';
-    this._reactProps.onKeyDown = this._onRadioKeyDown;
-    this._reactProps.onChange = this._onRadioKeyDown;
+    this._reactProps.onKeyDown = this._onKeyDown;
+    this._reactProps.onChange = this._onKeyDown;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  set enableKeyEvents(enable) {
+    super.enableKeyEvents = enable;
+    this._reactProps.onKeyDown = this._onKeyDown;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get enableKeyEvents() {
+    return super.enableKeyEvents;
   }
 
   /**
@@ -80,13 +95,18 @@ export default class RadioData extends InputTagData {
   }
 
   /**
-   * Keydown listener for when the radio button is pressed
-   * @access private
-   * @param {SyntheticEvent} e - React event
+   * @inheritdoc
    */
-  _onRadioKeyDown(e) {
-    if ([KeyCodes.enter, KeyCodes.space].indexOf(e.keyCode) !== -1) {
-      const event = new createjs.Event('keyboardClick', false, e.cancelable);
+  _onKeyDown(evt) {
+    if (this.enableKeyEvents) {
+      super._onKeyDown(evt);
+      if (evt.defaultPrevented) {
+        return;
+      }
+    }
+
+    if (evt.keyCode === KeyCodes.enter || evt.keyCode === KeyCodes.space) {
+      const event = new createjs.Event('keyboardClick', false, evt.cancelable);
       this._displayObject.dispatchEvent(event);
     }
   }

--- a/src/RoleObjects/RangeData.js
+++ b/src/RoleObjects/RangeData.js
@@ -2,75 +2,75 @@ import AccessibilityObject from './AccessibilityObject';
 
 export default class RangeData extends AccessibilityObject {
   /**
-  * Set value
-  * @access public
-  * @param {Number} val - current value
-  */
+   * Set value
+   * @access public
+   * @param {Number} val - current value
+   */
   set value(val) {
     this._reactProps['aria-valuenow'] = val;
   }
 
   /**
-  * get value
-  * @access public
-  * @returns {Number}  current value
-  */
+   * get value
+   * @access public
+   * @returns {Number}  current value
+   */
   get value() {
     return this._reactProps['aria-valuenow'];
   }
 
   /**
-  * Set min value
-  * @access public
-  * @param {Number} val - min value
-  */
+   * Set min value
+   * @access public
+   * @param {Number} val - min value
+   */
   set min(val) {
     this._reactProps['aria-valuemin'] = val;
   }
 
   /**
-  * get min value
-  * @access public
-  * @returns {Number}  min value
-  */
+   * get min value
+   * @access public
+   * @returns {Number}  min value
+   */
   get min() {
     return this._reactProps['aria-valuemin'];
   }
 
   /**
-  * Set max value
-  * @access public
-  * @param {Number} val - max value
-  */
+   * Set max value
+   * @access public
+   * @param {Number} val - max value
+   */
   set max(val) {
     this._reactProps['aria-valuemax'] = val;
   }
 
   /**
-  * get max value
-  * @access public
-  * @returns {Number} - max value
-  */
+   * get max value
+   * @access public
+   * @returns {Number} - max value
+   */
   get max() {
     return this._reactProps['aria-valuemax'];
   }
 
   /**
-  * If the valuetext attribute is set, authors SHOULD also set the value attribute,
-  * unless that value is unknown
-  * Set the human readable text alternative of aria-valuenow for a range widget.
-  * @access public
-  * @param {String} val - text value
-  */
-  set valuetext(val) {
+   * If the valuetext attribute is set, authors SHOULD also set the value attribute,
+   * unless that value is unknown
+   * Set the human readable text alternative of aria-valuenow for a range widget.
+   * @access public
+   * @param {String} val - text value
+   */
+  set valueText(val) {
     this._reactProps['aria-valuetext'] = val;
   }
 
   /**
-  * get text value
-  * @access public
-  */
-  get valuetext() {
+   * get text value
+   * @access public
+   */
+  get valueText() {
     return this._reactProps['aria-valuetext'];
   }
 }

--- a/src/RoleObjects/RowData.js
+++ b/src/RoleObjects/RowData.js
@@ -40,7 +40,7 @@ export default class RowData extends GroupData {
    * @access public
    * @param {Number} val - Positive number
    */
-  set colindex(val) {
+  set colIndex(val) {
     this._reactProps['aria-colindex'] = val;
   }
 
@@ -50,7 +50,7 @@ export default class RowData extends GroupData {
    * @access public
    * @returns {Number} - Positive number
    */
-  get colindex() {
+  get colIndex() {
     return this._reactProps['aria-colindex'];
   }
 
@@ -60,7 +60,7 @@ export default class RowData extends GroupData {
    * @access public
    * @param {Number} val - Positive number
    */
-  set rowindex(val) {
+  set rowIndex(val) {
     this._reactProps['aria-rowindex'] = val;
   }
 
@@ -70,7 +70,7 @@ export default class RowData extends GroupData {
    * @access public
    * @returns {Number} - Positive number
    */
-  get rowindex() {
+  get rowIndex() {
     return this._reactProps['aria-rowindex'];
   }
 

--- a/src/RoleObjects/ScrollBarData.js
+++ b/src/RoleObjects/ScrollBarData.js
@@ -5,56 +5,88 @@ import RangeData from './RangeData';
 export default class ScrollBarData extends RangeData {
   constructor(displayObject, role, domIdPrefix) {
     super(displayObject, role, domIdPrefix);
-    _.bindAll(this, 'onKeyDown');
-    this._reactProps.onKeyDown = this.onKeyDown;
-    this.incrementor = 20;
-    this._scrollAmt = 0;
+    _.bindAll(this, '_onKeyDown');
+    this._reactProps.onKeyDown = this._onKeyDown;
+
+    /**
+     * Amount to increment or decrement the value by when the arrow keys are pressed
+     * @access public
+     */
+    this.increment = 20;
+
+    // setup defaults per WAI-ARIA
+    this.min = 0;
+    this.max = 100;
+    this.value = (this.max + this.min) / 2;
   }
 
-  set controls(value) {
-    this._reactProps['aria-controls'] = value;
+  /**
+   * @inheritdoc
+   */
+  set enableKeyEvents(enable) {
+    super.enableKeyEvents = enable;
+    this._reactProps.onKeyDown = this._onKeyDown;
   }
 
-  get controls() {
-    return this._reactProps['aria-controls'];
+  /**
+   * @inheritdoc
+   */
+  get enableKeyEvents() {
+    return super.enableKeyEvents;
   }
 
-  set orientation(value) {
-    this._reactProps['aria-orientation'] = value;
+  /**
+   * Sets the orientation
+   * @access public
+   * @param {String} str - "horizontal" for a horizontal slider, "vertical" for a vertical scrollbar
+   */
+  set orientation(str) {
+    this._reactProps['aria-orientation'] = str;
   }
 
+  /**
+   * Retrieves the orientation
+   * @access public
+   * @returns  {String} str "horizontal" for a horizontal slider, "vertical" for a vertical scrollbar
+   */
   get orientation() {
     return this._reactProps['aria-orientation'];
   }
 
-  set scrollAmount(value) {
-    this._scrollAmt = value;
-  }
+  /**
+   * @inheritdoc
+   */
+  _onKeyDown(e) {
+    if (this.enableKeyEvents) {
+      super._onKeyDown(evt);
+      if (evt.defaultPrevented) {
+        return;
+      }
+    }
 
-  onKeyDown(e) {
     if (this.orientation !== 'horizontal') {
       if (e.keyCode === KeyCodes.up || e.keyCode === KeyCodes.down) {
         e.stopPropagation();
         e.preventDefault();
         if (e.keyCode === KeyCodes.up) {
-          this._scrollAmt -= this.incrementor;
+          this.value = Math.max(this.value - this.increment, this.min);
         } else {
-          this._scrollAmt += this.incrementor;
+          this.value = Math.min(this.value + this.increment, this.max);
         }
         const event = new createjs.Event('scroll', false, e.cancelable);
-        event.scrollTop = this._scrollAmt;
+        event.scrollTop = this.value;
         this._displayObject.dispatchEvent(event);
       }
     } else if (e.keyCode === KeyCodes.left || e.keyCode === KeyCodes.right) {
       e.stopPropagation();
       e.preventDefault();
       if (e.keyCode === KeyCodes.left) {
-        this._scrollAmt -= this.incrementor;
+        this.value = Math.max(this.value - this.increment, this.min);
       } else {
-        this._scrollAmt += this.incrementor;
+        this.value = Math.min(this.value + this.increment, this.max);
       }
       const event = new createjs.Event('scroll', false, e.cancelable);
-      event.scrollLeft = this._scrollAmt;
+      event.scrollLeft = this.value;
       this._displayObject.dispatchEvent(event);
     }
   }

--- a/src/RoleObjects/ScrollBarData.js
+++ b/src/RoleObjects/ScrollBarData.js
@@ -47,7 +47,8 @@ export default class ScrollBarData extends RangeData {
   /**
    * Retrieves the orientation
    * @access public
-   * @returns  {String} str "horizontal" for a horizontal slider, "vertical" for a vertical scrollbar
+   * @returns  {String} str "horizontal" for a horizontal slider,
+   * "vertical" for a vertical scrollbar
    */
   get orientation() {
     return this._reactProps['aria-orientation'];
@@ -56,7 +57,7 @@ export default class ScrollBarData extends RangeData {
   /**
    * @inheritdoc
    */
-  _onKeyDown(e) {
+  _onKeyDown(evt) {
     if (this.enableKeyEvents) {
       super._onKeyDown(evt);
       if (evt.defaultPrevented) {
@@ -65,27 +66,27 @@ export default class ScrollBarData extends RangeData {
     }
 
     if (this.orientation !== 'horizontal') {
-      if (e.keyCode === KeyCodes.up || e.keyCode === KeyCodes.down) {
-        e.stopPropagation();
-        e.preventDefault();
-        if (e.keyCode === KeyCodes.up) {
+      if (evt.keyCode === KeyCodes.up || evt.keyCode === KeyCodes.down) {
+        evt.stopPropagation();
+        evt.preventDefault();
+        if (evt.keyCode === KeyCodes.up) {
           this.value = Math.max(this.value - this.increment, this.min);
         } else {
           this.value = Math.min(this.value + this.increment, this.max);
         }
-        const event = new createjs.Event('scroll', false, e.cancelable);
+        const event = new createjs.Event('scroll', false, evt.cancelable);
         event.scrollTop = this.value;
         this._displayObject.dispatchEvent(event);
       }
-    } else if (e.keyCode === KeyCodes.left || e.keyCode === KeyCodes.right) {
-      e.stopPropagation();
-      e.preventDefault();
-      if (e.keyCode === KeyCodes.left) {
+    } else if (evt.keyCode === KeyCodes.left || evt.keyCode === KeyCodes.right) {
+      evt.stopPropagation();
+      evt.preventDefault();
+      if (evt.keyCode === KeyCodes.left) {
         this.value = Math.max(this.value - this.increment, this.min);
       } else {
         this.value = Math.min(this.value + this.increment, this.max);
       }
-      const event = new createjs.Event('scroll', false, e.cancelable);
+      const event = new createjs.Event('scroll', false, evt.cancelable);
       event.scrollLeft = this.value;
       this._displayObject.dispatchEvent(event);
     }

--- a/src/RoleObjects/SingleLineTextBoxData.js
+++ b/src/RoleObjects/SingleLineTextBoxData.js
@@ -61,8 +61,8 @@ export default class SingleLineTextBoxData extends InputTagData {
    * @access public
    * @param {boolean} enable - true if autocomplete should be enabled, false otherwise
    */
-  set autocomplete(enable) {
-    this._reactProps.autocomplete = enable ? 'on' : 'off';
+  set autoComplete(enable) {
+    this._reactProps.autoComplete = enable ? 'on' : 'off';
   }
 
   /**
@@ -70,8 +70,8 @@ export default class SingleLineTextBoxData extends InputTagData {
    * @access public
    * @returns {boolean} true if autocomplete is enabled, false otherwise
    */
-  get autocomplete() {
-    return this._reactProps.autocomplete === 'on';
+  get autoComplete() {
+    return this._reactProps.autoComplete === 'on';
   }
 
   /**

--- a/src/RoleObjects/SingleSelectListBoxData.js
+++ b/src/RoleObjects/SingleSelectListBoxData.js
@@ -215,6 +215,9 @@ export default class SingleSelectListBoxData extends SelectData {
   _onKeyDown(evt) {
     if (this.enableKeyEvents) {
       super._onKeyDown(evt);
+      if (evt.defaultPrevented) {
+        return;
+      }
     }
 
     if (evt.keyCode === KeyCodes.down) {

--- a/src/RoleObjects/SingleSelectListBoxData.js
+++ b/src/RoleObjects/SingleSelectListBoxData.js
@@ -51,8 +51,8 @@ export default class SingleSelectListBoxData extends SelectData {
    * @access public
    * @param {boolean} enable - true if autofocus should be enabled, false otherwise
    */
-  set autofocus(enable) {
-    this._reactProps.autofocus = enable ? 'autofocus' : undefined;
+  set autoFocus(enable) {
+    this._reactProps.autoFocus = enable ? 'autofocus' : undefined;
   }
 
   /**
@@ -60,8 +60,8 @@ export default class SingleSelectListBoxData extends SelectData {
    * @access public
    * @returns {boolean} true if autofocus is enabled, false otherwise
    */
-  get autofocus() {
-    return this._reactProps.autofocus === 'autofocus';
+  get autoFocus() {
+    return this._reactProps.autoFocus === 'autofocus';
   }
 
   /**

--- a/src/RoleObjects/SpinButtonData.js
+++ b/src/RoleObjects/SpinButtonData.js
@@ -5,10 +5,10 @@ import RangeData from './RangeData';
 export default class SpinButtonData extends RangeData {
   constructor(displayObject, role, domIdPrefix) {
     super(displayObject, role, domIdPrefix);
-    _.bindAll(this, '_onChange');
+    _.bindAll(this, '_onKeyDown', '_onChange');
+    this._reactProps.onKeyDown = this._onKeyDown;
     this._reactProps.onChange = this._onChange;
     this._reactProps.type = 'number';
-    this.enableKeyEvents = true;
   }
 
   /**
@@ -25,6 +25,9 @@ export default class SpinButtonData extends RangeData {
     throw new Error(`${this.role} cannot have children`);
   }
 
+  /**
+   * @inheritdoc
+   */
   set enableKeyEvents(enable) {
     super.enableKeyEvents = enable;
     // the keydown listener is needed for this role to function per WAI-ARIA practices
@@ -32,6 +35,9 @@ export default class SpinButtonData extends RangeData {
     this._reactProps.onKeyDown = this._onKeyDown;
   }
 
+  /**
+   * @inheritdoc
+   */
   get enableKeyEvents() {
     return super.enableKeyEvents;
   }
@@ -126,9 +132,15 @@ export default class SpinButtonData extends RangeData {
     return this._reactProps['aria-required'];
   }
 
+  /**
+   * @inheritdoc
+   */
   _onKeyDown(evt) {
     if (this.enableKeyEvents) {
       super._onKeyDown(evt);
+      if (evt.defaultPrevented) {
+        return;
+      }
     }
 
     if (evt.keyCode === KeyCodes.up) {

--- a/src/RoleObjects/TabData.js
+++ b/src/RoleObjects/TabData.js
@@ -5,8 +5,23 @@ import AccessibilityObject from './AccessibilityObject';
 export default class TabData extends AccessibilityObject {
   constructor(displayObject, role, domIdPrefix) {
     super(displayObject, role, domIdPrefix);
-    _.bindAll(this, '_onTabKeyDown');
-    this._reactProps.onKeyDown = this._onTabKeyDown;
+    _.bindAll(this, '_onKeyDown');
+    this._reactProps.onKeyDown = this._onKeyDown;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  set enableKeyEvents(enable) {
+    super.enableKeyEvents = enable;
+    this._reactProps.onKeyDown = this._onKeyDown;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get enableKeyEvents() {
+    return super.enableKeyEvents;
   }
 
   /**
@@ -76,11 +91,16 @@ export default class TabData extends AccessibilityObject {
   }
 
   /**
-   * Keydown listener for when the radio button is pressed
-   * @access private
-   * @param {SyntheticEvent} e - React event
+   * @inheritdoc
    */
-  _onTabKeyDown(e) {
+  _onKeyDown(e) {
+    if (this.enableKeyEvents) {
+      super._onKeyDown(evt);
+      if (evt.defaultPrevented) {
+        return;
+      }
+    }
+
     if ([KeyCodes.enter, KeyCodes.space].indexOf(e.keyCode) !== -1) {
       const event = new createjs.Event('keyboardClick', false, e.cancelable);
       this._displayObject.dispatchEvent(event);

--- a/src/RoleObjects/TabData.js
+++ b/src/RoleObjects/TabData.js
@@ -93,7 +93,7 @@ export default class TabData extends AccessibilityObject {
   /**
    * @inheritdoc
    */
-  _onKeyDown(e) {
+  _onKeyDown(evt) {
     if (this.enableKeyEvents) {
       super._onKeyDown(evt);
       if (evt.defaultPrevented) {
@@ -101,8 +101,8 @@ export default class TabData extends AccessibilityObject {
       }
     }
 
-    if ([KeyCodes.enter, KeyCodes.space].indexOf(e.keyCode) !== -1) {
-      const event = new createjs.Event('keyboardClick', false, e.cancelable);
+    if ([KeyCodes.enter, KeyCodes.space].indexOf(evt.keyCode) !== -1) {
+      const event = new createjs.Event('keyboardClick', false, evt.cancelable);
       this._displayObject.dispatchEvent(event);
     }
   }

--- a/src/RoleObjects/TabListData.js
+++ b/src/RoleObjects/TabListData.js
@@ -5,21 +5,36 @@ import CompositeData from './CompositeData';
 export default class TabListData extends CompositeData {
   constructor(displayObject, role, domIdPrefix) {
     super(displayObject, role, domIdPrefix);
-    _.bindAll(this, '_onTabListKeyDown');
-    this._reactProps.onKeyDown = this._onTabListKeyDown;
+    _.bindAll(this, '_onKeyDown');
+    this._reactProps.onKeyDown = this._onKeyDown;
   }
+
   /**
-   *  hierarchical level of the tabs within other structures
+   * @inheritdoc
+   */
+  set enableKeyEvents(enable) {
+    super.enableKeyEvents = enable;
+    this._reactProps.onKeyDown = this._onKeyDown;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get enableKeyEvents() {
+    return super.enableKeyEvents;
+  }
+
+  /**
+   * hierarchical level of the tabs within other structures
    * @access public
    * @param {Number} val - aria-level is an integer greater than or equal to 1
    */
-
   set level(val) {
     this._reactProps['aria-level'] = val;
   }
 
   /**
-   *  hierarchical level of the tabs within other structures
+   * hierarchical level of the tabs within other structures
    * @access public
    * @param {Number} val - aria-level is an integer greater than or equal to 1
    */
@@ -46,30 +61,35 @@ export default class TabListData extends CompositeData {
   }
 
   /**
-    * Sets the orientation of tablist
-    * @access public
-    * @param {String} str - "horizontal" for a horizontal tablist, "vertical" for a vertical tablist
-    */
+   * Sets the orientation of tablist
+   * @access public
+   * @param {String} str - "horizontal" for a horizontal tablist, "vertical" for a vertical tablist
+   */
   set orientation(str) {
     this._reactProps['aria-orientation'] = str;
   }
 
   /**
-    * Retrieves the orientation of tablist
-    * @access public
-    * @returns  {String} str "horizontal" for a horizontal tablist,
-    "vertical" for a vertical tablist
-    */
+   * Retrieves the orientation of tablist
+   * @access public
+   * @returns  {String} str "horizontal" for a horizontal tablist,
+   * "vertical" for a vertical tablist
+   */
   get orientation() {
     return this._reactProps['aria-orientation'];
   }
 
   /**
-   * Keydown listener for when the tablist is pressed
-   * @access private
-   * @param {SyntheticEvent} e - React event
+   * @inheritdoc
    */
-  _onTabListKeyDown(e) {
+  _onKeyDown(e) {
+    if (this.enableKeyEvents) {
+      super._onKeyDown(e);
+      if (e.defaultPrevented) {
+        return;
+      }
+    }
+
     if ([KeyCodes.enter, KeyCodes.space].indexOf(e.keyCode) !== -1) {
       const event = new createjs.Event('keyboardClick', false, e.cancelable);
       this._displayObject.dispatchEvent(event);

--- a/src/RoleObjects/TableData.js
+++ b/src/RoleObjects/TableData.js
@@ -31,7 +31,7 @@ export default class TableData extends SectionData {
    * @access public
    * @param {Number} val - Positive number , -1 if its unknown.
    */
-  set rowcount(val) {
+  set rowCount(val) {
     this._reactProps['aria-rowcount'] = val;
   }
 
@@ -42,7 +42,7 @@ export default class TableData extends SectionData {
    * @access public
    * @returns {Number} - Positive number , -1 if its unknown.
    */
-  get rowcount() {
+  get rowCount() {
     return this._reactProps['aria-rowcount'];
   }
 
@@ -53,7 +53,7 @@ export default class TableData extends SectionData {
    * @access public
    * @param {Number} val - Positive number , -1 if its unknown.
    */
-  set colcount(val) {
+  set colCount(val) {
     this._reactProps['aria-colcount'] = val;
   }
 
@@ -64,7 +64,7 @@ export default class TableData extends SectionData {
    * @access public
    * @returns {Number} - Positive number , -1 if its unknown.
    */
-  get colcount() {
+  get colCount() {
     return this._reactProps['aria-colcount'];
   }
 }

--- a/src/RoleObjects/TimerData.js
+++ b/src/RoleObjects/TimerData.js
@@ -8,7 +8,7 @@ export default class TimerData extends AccessibilityObject {
    * undefined to unset the field.
    */
   set dateTime(time) {
-    this._reactProps.datetime = time;
+    this._reactProps.dateTime = time;
   }
 
   /**
@@ -18,6 +18,6 @@ export default class TimerData extends AccessibilityObject {
    * undefined if the field is unset.
    */
   get dateTime() {
-    return this._reactProps.datetime;
+    return this._reactProps.dateTime;
   }
 }

--- a/src/RoleObjects/TreeItemData.js
+++ b/src/RoleObjects/TreeItemData.js
@@ -8,8 +8,23 @@ import ListItemData from './ListItemData';
 export default class TreeItemData extends ListItemData {
   constructor(displayObject, role, domIdPrefix) {
     super(displayObject, role, domIdPrefix);
-    _.bindAll(this, 'onKeyDown');
-    this._reactProps.onKeyDown = this.onKeyDown;
+    _.bindAll(this, '_onKeyDown');
+    this._reactProps.onKeyDown = this._onKeyDown;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  set enableKeyEvents(enable) {
+    super.enableKeyEvents = enable;
+    this._reactProps.onKeyDown = this._onKeyDown;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get enableKeyEvents() {
+    return super.enableKeyEvents;
   }
 
   /**
@@ -84,11 +99,16 @@ export default class TreeItemData extends ListItemData {
   }
 
   /**
-   * Keydown listener for an tree item
-   * @access private
-   * @param {SyntheticEvent} evt - React event
+   * inheritdoc
    */
-  onKeyDown(evt) {
+  _onKeyDown(evt) {
+    if (this.enableKeyEvents) {
+      super._onKeyDown(evt);
+      if (evt.defaultPrevented) {
+        return;
+      }
+    }
+
     if (evt.keyCode === KeyCodes.enter) {
       const event = new createjs.Event('keyboardClick', false, evt.cancelable);
       const skipPreventDefault = this._displayObject.dispatchEvent(event);


### PR DESCRIPTION
- Consistent capitalization of getter/setter names to follow existing coding conventions
- Making sure keyboard listeners properly inherit/override from the base class and allow for consuming apps to skip CAM default behavior via preventDefault
- Updating tested browsers/screen reader combos based on testing with these changes
- Since people have mistaken `reactProps` as public despite the comment designating its access level as package, removing the getter and updating the internal `_reactProps` field as package instead of private
- Adjusting which subclass of AccessibilityObject is used for the time text format to allow for setting the datetime attribute