### PR TITLE
fix(RoleObjectFactory): Resolve typo for removeChildAt call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Module to add accessibility support to createjs",
   "main": "dist/createjs-accessibility.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -136,4 +136,4 @@ Since the canvas tag was introduced in HTML5, an HTML5 compatible browser is req
 * Safari 13.1.3 (with and without VoiceOver)
 
 ## License
-The Createjs Accessibility Module is released under the ISC license.  https://opensource.org/licenses/ISC
+The Createjs Accessibility Module is released under the ISC license. https://opensource.org/licenses/ISC

--- a/readme.md
+++ b/readme.md
@@ -136,4 +136,4 @@ Since the canvas tag was introduced in HTML5, an HTML5 compatible browser is req
 * Safari 13.1.3 (with and without VoiceOver)
 
 ## License
-The Createjs Accessibility Module is released under the ISC license. https://opensource.org/licenses/ISC
+The Createjs Accessibility Module is released under the ISC license.  https://opensource.org/licenses/ISC

--- a/src/RoleObjectFactory.js
+++ b/src/RoleObjectFactory.js
@@ -93,7 +93,7 @@ function createAccessibilityObjectForRole(config) {
     parent = displayObject.accessible.parent;
     if (parent) {
       containerIndex = _.findIndex(parent.children, child => child === displayObject);
-      parent.removedChildAt(containerIndex);
+      parent.removeChildAt(containerIndex);
     }
   }
 


### PR DESCRIPTION
### Summary of Changes
Currently there seems to be a typo in CAM 1.0.0 that was introduced in #24:
https://github.com/CurriculumAssociates/createjs-accessibility/blob/6f8dc12d2f3111aa6389e2a47199419606867f5a/src/RoleObjectFactory.js#L96

It looks like it was trying to reference this method, but had an extra d.
https://github.com/CurriculumAssociates/createjs-accessibility/blob/6f8dc12d2f3111aa6389e2a47199419606867f5a/src/RoleObjects/AccessibilityObject.js#L119

This typo results in the following error:
```
`TypeError: obj.removedChildAt is not a function`
```
