### PR TITLE
Re-register parent type issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Module to add accessibility support to createjs",
   "main": "dist/createjs-accessibility.js",
   "scripts": {


### PR DESCRIPTION
When re-registering a DisplayObject, the logic for removing the previous AccessibilityObject instance was resulting in changing the type of a variable that would break the later code for adding the registered DisplayObject to the a11y tree as part of registering.  Also, the re-register case would override the passed `parent` and `containerIndex` params if they were specified, leading to the object being in a different position of the a11y tree than the caller specified.  That has also been corrected to only update those values in the re-register case if they were unspecified.