### PR TITLE
Canvas attribute css scaling for issue 43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Module to add accessibility support to createjs",
   "main": "dist/createjs-accessibility.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -18,32 +18,34 @@ function positionElemUnderStage(stage, getComponentRef) {
 
   const { canvas } = stage;
 
-  const {
-    height,
-    width,
-    border,
-    boxSizing,
-    margin,
-    padding,
-    transform,
-    transformOrigin,
-  } = getComputedStyle(canvas);
+  const computedStyle = getComputedStyle(canvas);
+  const width = parseInt(computedStyle.width, 10);
+  const height = parseInt(computedStyle.height, 10);
+
+  const attrWidth = parseInt(canvas.getAttribute('width'), 10) || width;
+  const attrHeight = parseInt(canvas.getAttribute('height'), 10) || height;
+
+  const scaleX = width / attrWidth;
+  const scaleY = height / attrHeight;
+
+  console.log(`mnewcomb: aw ${attrWidth} ah ${attrHeight} w ${width} h ${height} sx ${scaleX} sy ${scaleY}`);
 
   const moduleStyle = {
     overflow: 'hidden',
     position: 'absolute',
-    left: debugPos ? canvas.offsetLeft + parseInt(canvas.getAttribute('width'), 10) : 'auto',
+    left: debugPos ? canvas.offsetLeft + attrWidth * scaleX : 'auto',
     top: canvas.offsetTop,
     zIndex: debugPos ? 'auto' : -1,
-    height,
-    width,
-    border,
-    boxSizing,
-    margin,
-    padding,
-    transform,
-    transformOrigin,
+    height: attrHeight,
+    width: attrWidth,
+    border: computedStyle.border,
+    boxSizing: computedStyle.boxSizing,
+    margin: computedStyle.margin,
+    padding: computedStyle.padding,
+    transform: `scaleX(${scaleX}) scaleY(${scaleY})`,
+    transformOrigin: 'top left',
   };
+  console.log(moduleStyle);
 
   return (
     <div style={moduleStyle}>

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ function positionElemUnderStage(stage, getComponentRef) {
     height: attrHeight,
     width: attrWidth,
     border: computedStyle.border,
-    boxSizing: computedStyle.boxSizing,
+    boxSizing: computedStyle['box-sizing'],
     margin: computedStyle.margin,
     padding: computedStyle.padding,
     transform: `scaleX(${scaleX}) scaleY(${scaleY})`,

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ function positionElemUnderStage(stage, getComponentRef) {
   const scaleX = width / attrWidth;
   const scaleY = height / attrHeight;
 
-  const moduleStyle = {
+  const transformStyle = {
     overflow: 'hidden',
     position: 'absolute',
     left: debugPos ? canvas.offsetLeft + attrWidth * scaleX : 'auto',
@@ -36,17 +36,26 @@ function positionElemUnderStage(stage, getComponentRef) {
     zIndex: debugPos ? 'auto' : -1,
     height: attrHeight,
     width: attrWidth,
+    marginLeft: computedStyle['margin-left'],
+    transform: computedStyle.transform,
+    transformOrigin: computedStyle.transformOrigin,
+  };
+
+  const moduleStyle = {
+    width: '100%',
+    height: '100%',
     border: computedStyle.border,
     boxSizing: computedStyle['box-sizing'],
-    margin: computedStyle.margin,
     padding: computedStyle.padding,
     transform: `scaleX(${scaleX}) scaleY(${scaleY})`,
     transformOrigin: 'top left',
   };
 
   return (
-    <div style={moduleStyle}>
-      <AccessibilityTranslator stage={stage} ref={getComponentRef} />
+    <div style={transformStyle}>
+      <div style={moduleStyle}>
+        <AccessibilityTranslator stage={stage} ref={getComponentRef} />
+      </div>
     </div>
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -28,8 +28,6 @@ function positionElemUnderStage(stage, getComponentRef) {
   const scaleX = width / attrWidth;
   const scaleY = height / attrHeight;
 
-  console.log(`mnewcomb: aw ${attrWidth} ah ${attrHeight} w ${width} h ${height} sx ${scaleX} sy ${scaleY}`);
-
   const moduleStyle = {
     overflow: 'hidden',
     position: 'absolute',
@@ -45,7 +43,6 @@ function positionElemUnderStage(stage, getComponentRef) {
     transform: `scaleX(${scaleX}) scaleY(${scaleY})`,
     transformOrigin: 'top left',
   };
-  console.log(moduleStyle);
 
   return (
     <div style={moduleStyle}>


### PR DESCRIPTION
Handle the canvas being scaled by the HTML width/height attributes being different than what CSS will lead the width/height to be.  This still accounts for CSS transforms and transform-origin values applied to the canvas element, as well as other properties that can affect dimensions and position.