### PR TITLE
Updated autoComplete getters to return true if undefined (true by default)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Module to add accessibility support to createjs",
   "main": "dist/createjs-accessibility.js",
   "scripts": {

--- a/src/RoleObjects/ComboBoxData.js
+++ b/src/RoleObjects/ComboBoxData.js
@@ -52,10 +52,10 @@ export default class ComboBoxData extends SelectData {
   /**
    * Retrieves whether autocomplete is enabled or not for the combobox
    * @access public
-   * @returns {boolean} true if autocomplete is enabled, false otherwise
+   * @returns {boolean} true if autocomplete is enabled (by default or explicitly), false otherwise
    */
   get autoComplete() {
-    return this._reactProps.autoComplete === 'on';
+    return this._reactProps.autoComplete === undefined || this._reactProps.autoComplete === 'on';
   }
 
   /**

--- a/src/RoleObjects/FormData.js
+++ b/src/RoleObjects/FormData.js
@@ -49,10 +49,10 @@ export default class FormData extends SectionData {
   /**
    * Retrieves whether autocomplete is enabled or not for the form
    * @access public
-   * @returns {boolean} true if autocomplete is enabled, false otherwise
+   * @returns {boolean} true if autocomplete is enabled (by default or explicitly), false otherwise
    */
   get autoComplete() {
-    return this._reactProps.autoComplete === 'on';
+    return this._reactProps.autoComplete === undefined || this._reactProps.autoComplete === 'on';
   }
 
   /**

--- a/src/RoleObjects/SingleLineTextBoxData.js
+++ b/src/RoleObjects/SingleLineTextBoxData.js
@@ -68,10 +68,10 @@ export default class SingleLineTextBoxData extends InputTagData {
   /**
    * Retrieves whether autocomplete is enabled
    * @access public
-   * @returns {boolean} true if autocomplete is enabled, false otherwise
+   * @returns {boolean} true if autocomplete is enabled (by default or explicitly), false otherwise
    */
   get autoComplete() {
-    return this._reactProps.autoComplete === 'on';
+    return this._reactProps.autoComplete === undefined || this._reactProps.autoComplete === 'on';
   }
 
   /**


### PR DESCRIPTION
Updated autoComplete getters in 3 files to also return true when the autoComplete prop is undefined, which would mean it is unset and is true by default (according to https://www.w3schools.com/tags/att_input_autocomplete.asp)