### PR TITLE
Added redirect and landing page templates for GitHub pages automation

### DIFF
--- a/base-page.html
+++ b/base-page.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CAM Test App</title>
+</head>
+<body>
+	<h1>CreateJS Accessibility Module</h1>
+	<p>Version: PACKAGE_VERSION</p>
+	<a href=test-app>Test App</a>
+</body>
+</html>

--- a/redirect-page.html
+++ b/redirect-page.html
@@ -1,0 +1,1 @@
+<script>document.location.replace("PACKAGE_VERSION");</script>


### PR DESCRIPTION
**base-page.html**
- template landing page for a specific version
- currently just a simple page with version and link to the test app for that version; future work will likely expand on this
- example on fork: https://helenxuyang.github.io/createjs-accessibility/1.0.7/

**redirect.html**
- when first opening the GitHub page without a version in the URL, will 
append /<latest-version-number> to the URL and auto-redirect.
- example on fork: https://helenxuyang.github.io/createjs-accessibility redirects to https://helenxuyang.github.io/createjs-accessibility/1.0.7/ because 1.0.7 is the latest version

Our GitHub Actions workflow will fill in PACKAGE_VERSION in these files upon publishing; that work is in https://github.com/CurriculumAssociates/createjs-accessibility/pull/58