### PR TITLE
Propagate Key along with keyCode in Keyboard Event

### DIFF
--- a/src/RoleObjects/AccessibilityObject.js
+++ b/src/RoleObjects/AccessibilityObject.js
@@ -823,7 +823,15 @@ export default class AccessibilityObject {
    */
   _onKeyDown(evt) {
     const event = new createjs.Event('keydown', false, evt.cancelable);
+    event.key = evt.key;
     event.keyCode = evt.keyCode;
+    Object.defineProperty(event, 'keyCode', {
+      get() {
+        // eslint-disable-next-line no-console
+        console.warn('"keyCode" Property is being deprecated, and will be removed in future major version of the createjs-accessibility module. Please use "key" property instead.');
+        return evt.keyCode;
+      },
+    });
     this._displayObject.dispatchEvent(event);
     if (event.propagationStopped) {
       evt.stopPropagation();
@@ -840,7 +848,15 @@ export default class AccessibilityObject {
    */
   _onKeyUp(evt) {
     const event = new createjs.Event('keyup', false, evt.cancelable);
+    event.key = evt.key;
     event.keyCode = evt.keyCode;
+    Object.defineProperty(event, 'keyCode', {
+      get() {
+        // eslint-disable-next-line no-console
+        console.warn('"keyCode" Property is being deprecated, and will be removed in future major version of the createjs-accessibility module. Please use "key" property instead.');
+        return evt.keyCode;
+      },
+    });
     this._displayObject.dispatchEvent(event);
     if (event.propagationStopped) {
       evt.stopPropagation();

--- a/src/RoleObjects/AccessibilityObject.test.js
+++ b/src/RoleObjects/AccessibilityObject.test.js
@@ -1,0 +1,35 @@
+import * as createjs from 'createjs-module';
+import ReactTestUtils from 'react-dom/test-utils';
+import AccessibilityModule from '../index';
+
+describe('Accessibility Objects', () => {
+  it('Accessibility Object should provide event and keycode with the event', () => {
+    const keyboardClickListener = jest.fn();
+    const canvas = document.createElement('canvas');
+    const parentEl = document.createElement('div');
+    const stage = new createjs.Stage(canvas);
+    const container = new createjs.Container();
+    window.createjs = createjs;
+    AccessibilityModule.register({
+      displayObject: container,
+      role: AccessibilityModule.ROLES.MAIN,
+      accessibleOptions: { enableKeyEvents: true },
+    });
+    AccessibilityModule.setupStage(stage, parentEl);
+    stage.accessibilityTranslator.root = container;
+    stage.addChild(container);
+    container.on('keydown', keyboardClickListener);
+    stage.update();
+    stage.accessibilityTranslator.update();
+
+    [['Enter', 13], ['a', 65], ['t', 84], ['Tab', 9]].forEach(([key, keyCode], i) => {
+      ReactTestUtils.Simulate.keyDown(parentEl.querySelector('main'), { keyCode, key });
+      const keyboardListenerArgument = keyboardClickListener.mock.calls[i][0];
+      const receivedKey = keyboardListenerArgument.key;
+      const receivedkeyCode = keyboardListenerArgument.keyCode;
+
+      expect(receivedKey).toBe(key);
+      expect(receivedkeyCode).toBe(keyCode);
+    });
+  });
+});


### PR DESCRIPTION
- Added 'key' property along with the existing 'keyCode' property in the Keyboard Events.

- Added a deprecation warning to warn if 'keyCode' is used.

- Added a unit test to Test if both 'key' and 'keyCode' property are passed in the event.