### PR TITLE
Wire-up Unit Test coverage reports in GitHub

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,3 +28,6 @@ jobs:
           npm run build
       - name: Test Coverage
         uses: ArtiomTr/jest-coverage-report-action@v2.0.4
+        with:
+          ref: ${{ env.BRANCH }}
+          fetch-depth: 0

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,9 +1,9 @@
 # This workflow will run tests using node, triggered via push
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
-name: Push
+name: Checks
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:
@@ -26,3 +26,5 @@ jobs:
           npm ci
           npm run lint
           npm run build
+      - name: Test Coverage
+        uses: ArtiomTr/jest-coverage-report-action@v2

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,5 +32,5 @@ jobs:
       - name: Test Coverage
         uses: ArtiomTr/jest-coverage-report-action@v2.0.4
         with:
-          coverage-file: ./coverage/report.json
-          base-coverage-file: ./coverage/report.json
+          coverage-file: report.json
+          base-coverage-file: report.json

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,18 +20,17 @@ jobs:
           npm ci
           npm run lint
           npm run build
-      - name: Lint and build test app
-        working-directory: ./test-app
+#      - name: Lint and build test app
+#        working-directory: ./test-app
+#        run: |
+#          npm ci
+#          npm run lint
+#          npm run build
+      - name: Run Unit Tests
         run: |
-          npm ci
-          npm run lint
-          npm run build
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          npx jest --ci --json --coverage --testLocationInResults --outputFile=report.json
       - name: Test Coverage
         uses: ArtiomTr/jest-coverage-report-action@v2.0.4
-
+        with:
+#          coverage-file: ./coverage/report.json
+          base-coverage-file: ./coverage/report.json

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,8 +26,12 @@ jobs:
           npm ci
           npm run lint
           npm run build
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Test Coverage
         uses: ArtiomTr/jest-coverage-report-action@v2.0.4
-        with:
-          ref: ${{ env.BRANCH }}
-          fetch-depth: 0
+

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,4 +27,4 @@ jobs:
           npm run lint
           npm run build
       - name: Test Coverage
-        uses: ArtiomTr/jest-coverage-report-action@v2
+        uses: ArtiomTr/jest-coverage-report-action@v2.0.4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,5 +32,5 @@ jobs:
       - name: Test Coverage
         uses: ArtiomTr/jest-coverage-report-action@v2.0.4
         with:
-#          coverage-file: ./coverage/report.json
+          coverage-file: ./coverage/report.json
           base-coverage-file: ./coverage/report.json

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,9 +8,20 @@ module.exports = {
   // The directory where Jest should output its coverage files
   coverageDirectory: 'coverage',
 
+  // This will be used to configure minimum threshold enforcement for coverage results.
+  coverageThreshold: {
+    global: {
+      branches: 10,
+      functions: 4,
+      lines: 7,
+      statements: 7,
+    },
+  },
+
+  // The paths to modules that run some code to configure or set up the testing environment before
+  // each test
+  setupFiles: ['jest-canvas-mock'],
+
   // The test environment that will be used for testing
   testEnvironment: 'jsdom',
-
-  // The paths to modules that run some code to configure or set up the testing environment before each test
-  setupFiles: ['jest-canvas-mock'],
 };

--- a/src/RoleObjects/SingleLineTextBoxData.js
+++ b/src/RoleObjects/SingleLineTextBoxData.js
@@ -59,7 +59,8 @@ export default class SingleLineTextBoxData extends InputTagData {
   /**
    * Sets whether the form should have autocomplete enabled
    * @access public
-   * @param {string | boolean} value - valid autocomplete attribute value to enable, false or off otherwise
+   * @param {string | boolean} value - valid autocomplete attribute value to enable,
+   *    false or off otherwise
    * @throws error if the specified value is invalid
    */
   set autoComplete(value) {
@@ -75,7 +76,8 @@ export default class SingleLineTextBoxData extends InputTagData {
   /**
    * Retrieves whether autocomplete is enabled
    * @access public
-   * @returns {string | boolean} attribute value if autocomplete is enabled by default or explicitly (note: true if undefined because autocomplete is enabled by default)
+   * @returns {string | boolean} attribute value if autocomplete is enabled by default
+   *    or explicitly (note: true if undefined because autocomplete is enabled by default)
    */
   get autoComplete() {
     if (this._reactProps.autoComplete !== undefined) return this._reactProps.autoComplete;

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,11 @@ import { ROLES } from './Roles';
  * @returns {Object} style object for positioning associated DOM elements
  */
 function calcDomStylesFromStage(stage) {
-  // true to return style object for putting the DOM element adjacent to the canvas (useful for debugging),
-  // false to return style object to put the DOM beneath the canvas
+  // true
+  //    to return style object for putting the DOM element adjacent to the canvas
+  //    (useful for debugging)
+  // false
+  //    to return style object to put the DOM beneath the canvas
   const debugPos = false;
 
   const { canvas } = stage;


### PR DESCRIPTION
# Changes/Updates
- added pull_request to on:
- changed `push.yml` to `checks.yml` to more accurately reflect the use case
- added `ArtiomTr/jest-coverage-report-action@v2` from GitHub Marketplace
- added minimum Unit Test pass/fail thresholds based on current values
- minor linting tech debt (lines too long)