### PR TITLE
Build Issue

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,9 +3,9 @@
 
 name: Publish
 
-on: [push]
-  # release:
-  #   types: [created]
+on:
+  release:
+    types: [created]
 
 jobs:
   publish-npm:
@@ -61,6 +61,6 @@ jobs:
         run: |
           npm ci
           npm run build
-          npm publish --dry-run
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -50,11 +50,11 @@ jobs:
           cd ${{ steps.get-package-version.outputs.PACKAGE_VERSION }}
           cp ../base-page.html index.html 
           sed -i 's/PACKAGE_VERSION/${{ steps.get-package-version.outputs.PACKAGE_VERSION }}/' index.html
-          # git config user.name github-actions
-          # git config user.email github-actions@github.com
-          # git add .
-          # git commit -m "Generated gh-pages files"
-          # git push  
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "Generated gh-pages files"
+          git push
       - name: Checkout main before publish
         uses: actions/checkout@v2
       - name: Publish

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,9 +3,9 @@
 
 name: Publish
 
-on:
-  release:
-    types: [created]
+on: [push]
+  # release:
+  #   types: [created]
 
 jobs:
   publish-npm:
@@ -50,14 +50,17 @@ jobs:
           cd ${{ steps.get-package-version.outputs.PACKAGE_VERSION }}
           cp ../base-page.html index.html 
           sed -i 's/PACKAGE_VERSION/${{ steps.get-package-version.outputs.PACKAGE_VERSION }}/' index.html
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add .
-          git commit -m "Generated gh-pages files"
-          git push  
+          # git config user.name github-actions
+          # git config user.email github-actions@github.com
+          # git add .
+          # git commit -m "Generated gh-pages files"
+          # git push  
       - name: Checkout main before publish
         uses: actions/checkout@v2
       - name: Publish
-        run: npm publish
+        run: |
+          npm ci
+          npm run build
+          npm publish --dry-run
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
When a consumer tries to consume any CAM versions >= 1.0.5, the build fails & this PR tries to resolve the this issue by updating the CAM publish workflow.