### PR TITLE
Implemented missing focus indicators in test app

### DIFF
--- a/test-app/src/widgets/AppWindow.js
+++ b/test-app/src/widgets/AppWindow.js
@@ -1272,6 +1272,7 @@ export default class AppWindow extends createjs.Container {
 
     let options = {
       href: 'https://www.w3.org/WAI/WCAG20/quickref/?currentsidebar=#col_customize&levels=aaa',
+      tabIndex: 0,
       text: "W3C's guide to meeting WCAG requirements",
     };
     const wcag = new Link(options);
@@ -1282,6 +1283,7 @@ export default class AppWindow extends createjs.Container {
 
     options = {
       href: 'https://www.w3.org/TR/wai-aria-1.1/',
+      tabIndex: 0,
       text: "W3C's general guide to Accessible Rich Internet Applications",
     };
     const aria = new Link(options);
@@ -1291,6 +1293,7 @@ export default class AppWindow extends createjs.Container {
     document.accessible.addChild(aria);
     options = {
       href: 'https://www.w3.org/TR/html-aria/#allowed-aria-roles-states-and-properties',
+      tabIndex: 0,
       text: "W3C's guide to allowed ARIA roles, states, and properties",
     };
     const allowedAria = new Link(options);

--- a/test-app/src/widgets/Button.js
+++ b/test-app/src/widgets/Button.js
@@ -4,19 +4,10 @@ import AccessibilityModule from '@curriculumassociates/createjs-accessibility';
 export default class Button extends createjs.Container {
   constructor(options, tabIndex, callBack = _.noop) {
     super();
-    _.bindAll(
-      this,
-      '_onFocus',
-      '_onBlur',
-      '_onMouseDown',
-      '_onMouseUp',
-      '_onClick'
-    );
+    _.bindAll(this, '_onFocus', '_onBlur', '_onClick');
     this.callBack = callBack;
     this.addEventListener('focus', this._onFocus);
     this.addEventListener('blur', this._onBlur);
-    this.addEventListener('mousedown', this._onMouseDown);
-    this.addEventListener('mouseup', this._onMouseUp);
     this.addEventListener('click', this._onClick);
     this.addEventListener('keyboardClick', this._onClick);
 
@@ -35,16 +26,8 @@ export default class Button extends createjs.Container {
           listener: this._onBlur,
         },
         {
-          eventName: 'mousedown',
-          listener: this._onMouseDown,
-        },
-        {
-          eventName: 'mouseup',
-          listener: this._onMouseUp,
-        },
-        {
           eventName: 'keyboardClick',
-          listener: this._onMouseDown,
+          listener: this._onClick,
         },
       ],
     });
@@ -91,14 +74,6 @@ export default class Button extends createjs.Container {
     this.focusIndicator.visible = false;
   }
 
-  _onMouseDown() {
-    this.background.visible = false;
-  }
-
-  _onMouseUp() {
-    this.background.visible = true;
-  }
-
   _onClick(evt) {
     this.accessible.requestFocus();
     this.callBack(evt);
@@ -109,8 +84,10 @@ export default class Button extends createjs.Container {
     this.background.name = 'background';
     this.background.graphics
       .beginStroke('black')
-      .beginFill('#fff')
-      .drawRect(0, 0, this.width, this.height);
+      .beginFill('yellow')
+      .drawRect(0, 0, this.width, this.height)
+      .endFill()
+      .endStroke();
     this.addChild(this.background);
   }
 
@@ -121,7 +98,9 @@ export default class Button extends createjs.Container {
       .beginStroke('black')
       .setStrokeStyle(3)
       .beginFill('#fff')
-      .drawRect(0, 0, this.width, this.height);
+      .drawRect(0, 0, this.width, this.height)
+      .endFill()
+      .endStroke();
     this.addChild(this.focusIndicator);
     this.focusIndicator.visible = false;
   }

--- a/test-app/src/widgets/Button.js
+++ b/test-app/src/widgets/Button.js
@@ -84,10 +84,7 @@ export default class Button extends createjs.Container {
     this.background.name = 'background';
     this.background.graphics
       .beginStroke('black')
-      .beginFill('yellow')
-      .drawRect(0, 0, this.width, this.height)
-      .endFill()
-      .endStroke();
+      .drawRect(0, 0, this.width, this.height);
     this.addChild(this.background);
   }
 
@@ -95,12 +92,9 @@ export default class Button extends createjs.Container {
     this.focusIndicator = new createjs.Shape();
     this.focusIndicator.name = 'focusIndicator';
     this.focusIndicator.graphics
-      .beginStroke('black')
-      .setStrokeStyle(3)
-      .beginFill('#fff')
-      .drawRect(0, 0, this.width, this.height)
-      .endFill()
-      .endStroke();
+      .setStrokeStyle(5)
+      .beginStroke('#5FC1FA')
+      .drawRect(-2.5, -2.5, this.width + 5, this.height + 5);
     this.addChild(this.focusIndicator);
     this.focusIndicator.visible = false;
   }

--- a/test-app/src/widgets/Link.js
+++ b/test-app/src/widgets/Link.js
@@ -1,13 +1,34 @@
+import _ from 'lodash';
 import AccessibilityModule from '@curriculumassociates/createjs-accessibility';
 
 export default class Link extends createjs.Container {
   constructor(options) {
     super();
+    _.bindAll(this, '_onFocus', '_onBlur', '_onClick');
     AccessibilityModule.register({
       accessibleOptions: options,
       displayObject: this,
       role: AccessibilityModule.ROLES.LINK,
+      events: [
+        {
+          eventName: 'focus',
+          listener: this._onFocus,
+        },
+        {
+          eventName: 'blur',
+          listener: this._onBlur,
+        },
+        {
+          eventName: 'keyboardClick',
+          listener: this._onClick,
+        },
+      ],
     });
+
+    this._focusIndicator = new createjs.Shape();
+    this._focusIndicator.visible = false;
+
+    this.addChild(this._focusIndicator);
 
     this.accessible.download = options.download;
     this.accessible.href = options.href;
@@ -16,12 +37,27 @@ export default class Link extends createjs.Container {
     this.accessible.rel = options.rel;
     this.accessible.target = options.target;
     this.accessible.type = options.type;
+    this.accessible.tabIndex = options.tabIndex;
     if (options.text) {
       this._text = new createjs.Text(options.text, '16px Arial', '#0921EA');
-      this._text.addEventListener('click', () => {
-        window.open(this.accessible.href);
-        this._text.color = '#542189';
-      });
+      this._text.addEventListener('click', this._onClick);
+
+      const { x, width, height } = this._text.getBounds();
+      const paddingTopLeft = -3;
+      const paddingWidthHeight = 5;
+      this._focusIndicator.graphics
+        .setStrokeStyle(2)
+        .beginStroke('#000000')
+        .drawRect(
+          x + paddingTopLeft,
+          paddingTopLeft,
+          width + paddingWidthHeight,
+          height + paddingWidthHeight
+        );
+
+      this._text.addEventListener('focus', this._onFocus);
+      this._text.addEventListener('blur', this._onBlur);
+
       const hit = new createjs.Shape();
       hit.graphics
         .beginFill('#000')
@@ -35,5 +71,18 @@ export default class Link extends createjs.Container {
       this.addChild(this._text);
       this.accessible.text = options.text;
     }
+  }
+
+  _onClick() {
+    window.open(this.accessible.href, '_blank');
+    this._text.color = '#542189';
+  }
+
+  _onFocus() {
+    this._focusIndicator.visible = true;
+  }
+
+  _onBlur() {
+    this._focusIndicator.visible = false;
   }
 }

--- a/test-app/src/widgets/Link.js
+++ b/test-app/src/widgets/Link.js
@@ -42,18 +42,11 @@ export default class Link extends createjs.Container {
       this._text = new createjs.Text(options.text, '16px Arial', '#0921EA');
       this._text.addEventListener('click', this._onClick);
 
-      const { x, width, height } = this._text.getBounds();
-      const paddingTopLeft = -3;
-      const paddingWidthHeight = 5;
+      const { width, height } = this._text.getBounds();
       this._focusIndicator.graphics
-        .setStrokeStyle(2)
-        .beginStroke('#000000')
-        .drawRect(
-          x + paddingTopLeft,
-          paddingTopLeft,
-          width + paddingWidthHeight,
-          height + paddingWidthHeight
-        );
+        .setStrokeStyle(5)
+        .beginStroke('#5FC1FA')
+        .drawRect(-2.5, -2.5, width + 5, height + 5);
 
       this._text.addEventListener('focus', this._onFocus);
       this._text.addEventListener('blur', this._onBlur);

--- a/test-app/src/widgets/MenuItem.js
+++ b/test-app/src/widgets/MenuItem.js
@@ -38,21 +38,14 @@ export default class MenuItem extends createjs.Container {
   }
 
   setupFocusIndicator() {
-    const paddingTopLeft = -1.5;
-    const paddingWidthHeight = 3;
     const bounds = this.getBounds();
     this._focusIndicator = new createjs.Shape();
     this._focusIndicator.visible = false;
     this._focusIndicator.graphics
       .clear()
-      .setStrokeStyle(2)
-      .beginStroke('#000000')
-      .drawRect(
-        bounds.x + paddingTopLeft,
-        bounds.y + paddingTopLeft,
-        bounds.width + paddingWidthHeight,
-        bounds.height + paddingWidthHeight
-      );
+      .setStrokeStyle(5)
+      .beginStroke('#5FC1FA')
+      .drawRect(-2.5, -2.5, bounds.width + 5, bounds.height + 5);
     this.addChild(this._focusIndicator);
   }
 

--- a/test-app/src/widgets/MenuItem.js
+++ b/test-app/src/widgets/MenuItem.js
@@ -9,12 +9,10 @@ export default class MenuItem extends createjs.Container {
     super();
     _.bindAll(this, 'onFocus', 'onBlur');
 
-    this._focusIndicator = new createjs.Shape();
-    this._focusIndicator.visible = false;
-    this.addChild(this._focusIndicator);
-
     this._label = new createjs.Text(label, '16px Arial');
     this.addChild(this._label);
+
+    this.setupFocusIndicator();
 
     const bounds = this._label.getBounds();
     this._label.hitArea = new createjs.Shape();
@@ -39,12 +37,23 @@ export default class MenuItem extends createjs.Container {
     });
   }
 
-  setMenuWidth(x, width) {
+  setupFocusIndicator() {
+    const paddingTopLeft = -1.5;
+    const paddingWidthHeight = 3;
     const bounds = this.getBounds();
+    this._focusIndicator = new createjs.Shape();
+    this._focusIndicator.visible = false;
     this._focusIndicator.graphics
       .clear()
-      .beginFill('#31c7ec')
-      .drawRect(x, bounds.y, width, bounds.height);
+      .setStrokeStyle(2)
+      .beginStroke('#000000')
+      .drawRect(
+        bounds.x + paddingTopLeft,
+        bounds.y + paddingTopLeft,
+        bounds.width + paddingWidthHeight,
+        bounds.height + paddingWidthHeight
+      );
+    this.addChild(this._focusIndicator);
   }
 
   onFocus() {

--- a/test-app/src/widgets/SpinButton.js
+++ b/test-app/src/widgets/SpinButton.js
@@ -51,7 +51,7 @@ export default class SpinButton extends createjs.Container {
     });
 
     this.setBounds(0, 0, this.width, this.height);
-    this.setupFocusIndicator(0, 0, this.width, this.height);
+    this.setupFocusIndicator(this.width, this.height);
     this.createButtons();
   }
 
@@ -105,14 +105,13 @@ export default class SpinButton extends createjs.Container {
     this.callback();
   }
 
-  setupFocusIndicator(x, y, width, height) {
+  setupFocusIndicator(width, height) {
     this._focusIndicator = new createjs.Shape();
     this._focusIndicator.visible = false;
     this._focusIndicator.graphics
-      .setStrokeStyle(4)
-      .beginStroke('#000000')
-      .drawRect(x, y, width, height);
-
+      .setStrokeStyle(5)
+      .beginStroke('#5FC1FA')
+      .drawRect(-2.5, -2.5, width + 5, height + 5);
     this.addChild(this._focusIndicator);
   }
 

--- a/test-app/src/widgets/SpinButton.js
+++ b/test-app/src/widgets/SpinButton.js
@@ -39,10 +39,19 @@ export default class SpinButton extends createjs.Container {
           eventName: 'change',
           listener: this.onChange,
         },
+        {
+          eventName: 'focus',
+          listener: this.onFocus,
+        },
+        {
+          eventName: 'blur',
+          listener: this.onBlur,
+        },
       ],
     });
 
     this.setBounds(0, 0, this.width, this.height);
+    this.setupFocusIndicator(0, 0, this.width, this.height);
     this.createButtons();
   }
 
@@ -52,18 +61,18 @@ export default class SpinButton extends createjs.Container {
       value: '+',
       name: 'Increment',
       enabled: true,
-      autoFocus: false,
+      autoFocus: true,
       width: this.width,
       height: this.height * 0.5,
     };
     // Increment button
-    this.incBtn = new Button(options, -1, this.onIncrement.bind(this));
+    this.incBtn = new Button(options, 0, this.onIncrement.bind(this));
     this.addChild(this.incBtn);
 
     // Decrement button
     options.value = '-';
     options.name = 'Decrement';
-    this.decBtn = new Button(options, -1, this.onDecrement.bind(this));
+    this.decBtn = new Button(options, 0, this.onDecrement.bind(this));
     this.addChild(this.decBtn);
 
     this.decBtn.y = this.height * 0.5;
@@ -94,6 +103,25 @@ export default class SpinButton extends createjs.Container {
     this.targetContainer.text = this.currentValue;
     this.accessible.value = this.currentValue;
     this.callback();
+  }
+
+  setupFocusIndicator(x, y, width, height) {
+    this._focusIndicator = new createjs.Shape();
+    this._focusIndicator.visible = false;
+    this._focusIndicator.graphics
+      .setStrokeStyle(4)
+      .beginStroke('#000000')
+      .drawRect(x, y, width, height);
+
+    this.addChild(this._focusIndicator);
+  }
+
+  onFocus() {
+    this._focusIndicator.visible = true;
+  }
+
+  onBlur() {
+    this._focusIndicator.visible = false;
   }
 
   get width() {


### PR DESCRIPTION
This PR will add some focus indicators around some of the commonly used widgets in the test app that will enable a keyboard user to see the indicator while an element is in focus. Also to see best practices of keyboard navigation in the test app so that I can implement them in my own project that consumes CAM.

**What did I change**

1. Added a focus indicator in Button widget which has been used in Drag and Drop widget as Draggable
2. Added a focus indicator in the Link widget
3. Added focus indicator in the MenuItem and Spin Button widget
