### PR TITLE
Babel config fix for /test-app

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,9 @@
 module.exports = function babelConfig(api) {
   return {
+    babelrcRoots: [
+      '.',
+      './test-app',
+    ],
     presets: [
       ['@babel/preset-env', { modules: api.env(['test']) ? 'auto' : false }],
       '@babel/preset-typescript',


### PR DESCRIPTION
- fix roots so babel doesn't try to apply ./babel.config.js to /test-app
- fix is for failed publish as seen here: https://github.com/CurriculumAssociates/createjs-accessibility/actions/runs/3896562133/jobs/6653242213