### PR TITLE
Clean-up parent references when registering

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,9 @@
 module.exports = function babelConfig(api) {
   return {
+    babelrcRoots: [
+      '.',
+      './test-app',
+    ],
     presets: [
       ['@babel/preset-env', { modules: api.env(['test']) ? 'auto' : false }],
       '@babel/preset-typescript',

--- a/src/RoleObjectFactory.ts
+++ b/src/RoleObjectFactory.ts
@@ -139,6 +139,8 @@ function createAccessibilityObjectForRole(config: RoleObjectConfig) {
   }
 
   if (displayObject.accessible) {
+    displayObject.accessible.removeAllChildren();
+
     const prevParent = displayObject.accessible.parent;
     if (prevParent) {
       const prevContainerIndex = _.findIndex(
@@ -146,8 +148,6 @@ function createAccessibilityObjectForRole(config: RoleObjectConfig) {
         (child) => child === displayObject
       );
       prevParent.removeChildAt(prevContainerIndex);
-
-      displayObject.accessible.removeAllChildren();
 
       if (!parent) {
         parent = prevParent.displayObject;

--- a/src/RoleObjectFactory.ts
+++ b/src/RoleObjectFactory.ts
@@ -147,6 +147,8 @@ function createAccessibilityObjectForRole(config: RoleObjectConfig) {
       );
       prevParent.removeChildAt(prevContainerIndex);
 
+      displayObject.accessible.removeAllChildren();
+
       if (!parent) {
         parent = prevParent.displayObject;
         if (_.isUndefined(containerIndex)) {


### PR DESCRIPTION
- remove all children when unparenting

The fix here is to to call `removeAllChildren()` on the parent if it has already been registered:

**BEFORE**
![before_fix](https://user-images.githubusercontent.com/89026334/213014008-f44576ff-e2a4-415c-abbb-795686ce71f5.png)

**AFTER**
![after_fix](https://user-images.githubusercontent.com/89026334/213014051-007aa775-29c5-4721-a5a9-423e2b7bbf36.png)