### PR TITLE
Input and TextArea to echo keystrokes and cursor position

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "1.5.1",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@curriculumassociates/createjs-accessibility",
-      "version": "1.5.1",
+      "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.14.183",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@curriculumassociates/createjs-accessibility",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.14.183",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "1.5.1",
+  "version": "1.5.0",
   "description": "Module to add accessibility support to createjs",
   "main": "dist/createjs-accessibility.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curriculumassociates/createjs-accessibility",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Module to add accessibility support to createjs",
   "main": "dist/createjs-accessibility.js",
   "scripts": {

--- a/src/RoleObjects/MultiLineTextBoxData.js
+++ b/src/RoleObjects/MultiLineTextBoxData.js
@@ -374,7 +374,9 @@ export default class MultiLineTextBoxData extends AccessibilityObject {
       evt.keyCode === KeyCodes.left ||
       evt.keyCode === KeyCodes.right ||
       evt.keyCode === KeyCodes.up ||
-      evt.keyCode === KeyCodes.down
+      evt.keyCode === KeyCodes.down ||
+      evt.keyCode === KeyCodes.home ||
+      evt.keyCode === KeyCodes.end
     ) {
       this._onSelect(evt);
     }

--- a/src/RoleObjects/MultiLineTextBoxData.js
+++ b/src/RoleObjects/MultiLineTextBoxData.js
@@ -33,6 +33,8 @@ export default class MultiLineTextBoxData extends AccessibilityObject {
    */
   set enableKeyEvents(enable) {
     super.enableKeyEvents = enable;
+    // To make sure onKeyUp event listener is not removed by AccessibilityObject while enableKeyEvents is setted as false
+    this._reactProps.onKeyUp = this._onKeyUp;
   }
 
   /**

--- a/src/RoleObjects/MultiLineTextBoxData.js
+++ b/src/RoleObjects/MultiLineTextBoxData.js
@@ -29,6 +29,20 @@ export default class MultiLineTextBoxData extends AccessibilityObject {
   }
 
   /**
+   * @inheritdoc
+   */
+  set enableKeyEvents(enable) {
+    super.enableKeyEvents = enable;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get enableKeyEvents() {
+    return super.enableKeyEvents;
+  }
+
+  /**
    * Sets the currently active descendant of a composite widget
    * @access public
    * @param {createjs.DisplayObject} displayObject - DisplayObject that is the active descendant
@@ -347,6 +361,13 @@ export default class MultiLineTextBoxData extends AccessibilityObject {
    * @param {Event} evt
    */
   _onKeyUp(evt) {
+    if (this.enableKeyEvents) {
+      super._onKeyUp(evt);
+      if (evt.defaultPrevented) {
+        return;
+      }
+    }
+
     if (
       evt.keyCode === KeyCodes.left ||
       evt.keyCode === KeyCodes.right ||

--- a/src/RoleObjects/MultiLineTextBoxData.js
+++ b/src/RoleObjects/MultiLineTextBoxData.js
@@ -1,14 +1,17 @@
 import _ from 'lodash';
+import KeyCodes from 'keycodes-enum';
 import { ROLES } from '../Roles';
 import AccessibilityObject from './AccessibilityObject';
 
 export default class MultiLineTextBoxData extends AccessibilityObject {
   constructor(displayObject, role, domIdPrefix) {
     super(displayObject, role, domIdPrefix);
-    _.bindAll(this, '_onChange', '_onSelect');
+    _.bindAll(this, '_onChange', '_onSelect', '_onInput', '_onKeyUp');
     this._reactProps['aria-multiline'] = true;
     this._reactProps.onChange = this._onChange;
     this._reactProps.onSelect = this._onSelect;
+    this._reactProps.onInput = this._onInput;
+    this._reactProps.onKeyUp = this._onKeyUp;
   }
 
   /**
@@ -328,5 +331,29 @@ export default class MultiLineTextBoxData extends AccessibilityObject {
     event.selectionEnd = evt.currentTarget.selectionEnd;
     event.selectionDirection = evt.currentTarget.selectionDirection;
     this._displayObject.dispatchEvent(event);
+  }
+
+  /**
+   * event handler for when the element gets input
+   * @param {Event} evt
+   */
+  _onInput(evt) {
+    this._onChange(evt);
+    this._onSelect(evt);
+  }
+
+  /**
+   * event handler for when keyboard key is lifted Up
+   * @param {Event} evt
+   */
+  _onKeyUp(evt) {
+    if (
+      evt.keyCode === KeyCodes.left ||
+      evt.keyCode === KeyCodes.right ||
+      evt.keyCode === KeyCodes.up ||
+      evt.keyCode === KeyCodes.down
+    ) {
+      this._onSelect(evt);
+    }
   }
 }

--- a/src/RoleObjects/SingleLineTextBoxData.js
+++ b/src/RoleObjects/SingleLineTextBoxData.js
@@ -32,6 +32,8 @@ export default class SingleLineTextBoxData extends InputTagData {
    */
   set enableKeyEvents(enable) {
     super.enableKeyEvents = enable;
+    // To make sure onKeyUp event listener is not removed by AccessibilityObject while enableKeyEvents is setted as false
+    this._reactProps.onKeyUp = this._onKeyUp;
   }
 
   /**

--- a/src/RoleObjects/SingleLineTextBoxData.js
+++ b/src/RoleObjects/SingleLineTextBoxData.js
@@ -287,9 +287,9 @@ export default class SingleLineTextBoxData extends InputTagData {
    */
   _onSelect(evt) {
     const event = new createjs.Event('selectionChanged', false, false);
-    event.selectionStart = evt.target.selectionStart;
-    event.selectionEnd = evt.target.selectionEnd;
-    event.selectionDirection = evt.target.selectionDirection;
+    event.selectionStart = evt.currentTarget.selectionStart;
+    event.selectionEnd = evt.currentTarget.selectionEnd;
+    event.selectionDirection = evt.currentTarget.selectionDirection;
     this._displayObject.dispatchEvent(event);
   }
 

--- a/src/RoleObjects/SingleLineTextBoxData.js
+++ b/src/RoleObjects/SingleLineTextBoxData.js
@@ -28,6 +28,20 @@ export default class SingleLineTextBoxData extends InputTagData {
   }
 
   /**
+   * @inheritdoc
+   */
+  set enableKeyEvents(enable) {
+    super.enableKeyEvents = enable;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  get enableKeyEvents() {
+    return super.enableKeyEvents;
+  }
+
+  /**
    * Sets the currently active descendant of a composite widget
    * @access public
    * @param {createjs.DisplayObject} displayObject - DisplayObject that is the active descendant
@@ -307,6 +321,13 @@ export default class SingleLineTextBoxData extends InputTagData {
    * @param {Event} evt
    */
   _onKeyUp(evt) {
+    if (this.enableKeyEvents) {
+      super._onKeyUp(evt);
+      if (evt.defaultPrevented) {
+        return;
+      }
+    }
+
     if (evt.keyCode === KeyCodes.left || evt.keyCode === KeyCodes.right) {
       this._onSelect(evt);
     }

--- a/src/RoleObjects/SingleLineTextBoxData.js
+++ b/src/RoleObjects/SingleLineTextBoxData.js
@@ -1,13 +1,16 @@
 import _ from 'lodash';
+import KeyCodes from 'keycodes-enum';
 import InputTagData from './InputTagData';
 
 export default class SingleLineTextBoxData extends InputTagData {
   constructor(displayObject, role, domIdPrefix) {
     super(displayObject, role, domIdPrefix);
-    _.bindAll(this, '_onChange', '_onSelect');
+    _.bindAll(this, '_onChange', '_onSelect', '_onInput', '_onKeyUp');
     this._reactProps.type = 'text';
     this._reactProps.onChange = this._onChange;
     this._reactProps.onSelect = this._onSelect;
+    this._reactProps.onInput = this._onInput;
+    this._reactProps.onKeyUp = this._onKeyUp;
   }
 
   /**
@@ -284,9 +287,28 @@ export default class SingleLineTextBoxData extends InputTagData {
    */
   _onSelect(evt) {
     const event = new createjs.Event('selectionChanged', false, false);
-    event.selectionStart = evt.currentTarget.selectionStart;
-    event.selectionEnd = evt.currentTarget.selectionEnd;
-    event.selectionDirection = evt.currentTarget.selectionDirection;
+    event.selectionStart = evt.target.selectionStart;
+    event.selectionEnd = evt.target.selectionEnd;
+    event.selectionDirection = evt.target.selectionDirection;
     this._displayObject.dispatchEvent(event);
+  }
+
+  /**
+   * event handler for when the element gets input
+   * @param {Event} evt
+   */
+  _onInput(evt) {
+    this._onChange(evt);
+    this._onSelect(evt);
+  }
+
+  /**
+   * event handler for when keyboard key is lifted Up
+   * @param {Event} evt
+   */
+  _onKeyUp(evt) {
+    if (evt.keyCode === KeyCodes.left || evt.keyCode === KeyCodes.right) {
+      this._onSelect(evt);
+    }
   }
 }

--- a/src/RoleObjects/SingleLineTextBoxData.js
+++ b/src/RoleObjects/SingleLineTextBoxData.js
@@ -330,7 +330,12 @@ export default class SingleLineTextBoxData extends InputTagData {
       }
     }
 
-    if (evt.keyCode === KeyCodes.left || evt.keyCode === KeyCodes.right) {
+    if (
+      evt.keyCode === KeyCodes.left ||
+      evt.keyCode === KeyCodes.right ||
+      evt.keyCode === KeyCodes.home ||
+      evt.keyCode === KeyCodes.end
+    ) {
       this._onSelect(evt);
     }
   }

--- a/src/RoleObjects/__tests__/MultiLineTextBoxData.test.js
+++ b/src/RoleObjects/__tests__/MultiLineTextBoxData.test.js
@@ -291,8 +291,8 @@ describe('MultiLineTextBoxData', () => {
         expect(selectEventHandler).toBeCalledTimes(1);
       });
 
-      ['left', 'right', 'up', 'down'].forEach((key) => {
-        it(`can dispatch "selectionChanged" event when ${key} arrow key is pressed`, () => {
+      ['left', 'right', 'up', 'down', 'home', 'end'].forEach((key) => {
+        it(`can dispatch "selectionChanged" event when ${key} key is pressed`, () => {
           const selectEventHandler = jest.fn();
           cjsTextarea.on('selectionChanged', selectEventHandler);
           const keyCode = KeyCodes[key];

--- a/src/RoleObjects/__tests__/MultiLineTextBoxData.test.js
+++ b/src/RoleObjects/__tests__/MultiLineTextBoxData.test.js
@@ -1,4 +1,5 @@
 import * as createjs from 'createjs-module';
+import KeyCodes from 'keycodes-enum';
 import AccessibilityModule from '../../index';
 import { parentEl, stage, container } from '../../__tests__/__jestSharedSetup';
 
@@ -267,6 +268,51 @@ describe('MultiLineTextBoxData', () => {
         cjsTextarea.on('selectionChanged', selectEventHandler);
         textareaEl.dispatchEvent(new Event('select'));
         expect(selectEventHandler).toBeCalledTimes(1);
+      });
+    });
+
+    describe('"onInput" and "onKeyUp" event handlers', () => {
+      it('can dispatch "valueChanged" and "selectionChanged" event with every Input', () => {
+        const eventHandler = jest.fn();
+        cjsTextarea.on('valueChanged', eventHandler);
+        const selectEventHandler = jest.fn();
+        cjsTextarea.on('selectionChanged', selectEventHandler);
+
+        const updatedValue = 'updated value';
+        const inputEvent = new Event('input');
+        Object.defineProperty(inputEvent, 'target', {
+          value: { value: updatedValue },
+        });
+        textareaEl.dispatchEvent(inputEvent);
+
+        expect(eventHandler).toBeCalledTimes(1);
+        const argument = eventHandler.mock.calls[0][0];
+        expect(argument.newValue).toBe(updatedValue);
+        expect(selectEventHandler).toBeCalledTimes(1);
+      });
+
+      ['left', 'right', 'up', 'down'].forEach((key) => {
+        it(`can dispatch "selectionChanged" event when ${key} arrow key is pressed`, () => {
+          const selectEventHandler = jest.fn();
+          cjsTextarea.on('selectionChanged', selectEventHandler);
+          const keyCode = KeyCodes[key];
+          const keyUpEvent = new KeyboardEvent('keyup', { keyCode });
+          textareaEl.dispatchEvent(keyUpEvent);
+          expect(selectEventHandler).toBeCalledTimes(1);
+        });
+      });
+
+      it('does not dispatch "selectionChanged" event on Arrowkeys when default is prevented', () => {
+        const selectEventHandler = jest.fn();
+        cjsTextarea.accessible.enableKeyEvents = true;
+        cjsTextarea.on('selectionChanged', selectEventHandler);
+        const keyCode = KeyCodes.left;
+        const keyUpEvent = new KeyboardEvent('keyup', { keyCode });
+        Object.defineProperty(keyUpEvent, 'defaultPrevented', {
+          value: true,
+        });
+        textareaEl.dispatchEvent(keyUpEvent);
+        expect(selectEventHandler).toBeCalledTimes(0);
       });
     });
   });

--- a/src/RoleObjects/__tests__/SingleLineTextBoxData.test.js
+++ b/src/RoleObjects/__tests__/SingleLineTextBoxData.test.js
@@ -171,18 +171,15 @@ describe('SingleLineTextBoxData', () => {
         expect(selectEventHandler).toBeCalledTimes(1);
       });
 
-      it('can dispatch "selectionChanged" event when "left" or "right" arrow keys are pressed', () => {
-        const selectEventHandler = jest.fn();
-        cjsInput.on('selectionChanged', selectEventHandler);
-        let keyCode = KeyCodes.left;
-        let keyUpEvent = new KeyboardEvent('keyup', { keyCode });
-        inputEl.dispatchEvent(keyUpEvent);
-        expect(selectEventHandler).toBeCalledTimes(1);
-
-        keyCode = KeyCodes.right;
-        keyUpEvent = new KeyboardEvent('keyup', { keyCode });
-        inputEl.dispatchEvent(keyUpEvent);
-        expect(selectEventHandler).toBeCalledTimes(2);
+      ['left', 'right', 'home', 'end'].forEach((key) => {
+        it(`can dispatch "selectionChanged" event when ${key} key is pressed`, () => {
+          const selectEventHandler = jest.fn();
+          cjsInput.on('selectionChanged', selectEventHandler);
+          const keyCode = KeyCodes[key];
+          const keyUpEvent = new KeyboardEvent('keyup', { keyCode });
+          inputEl.dispatchEvent(keyUpEvent);
+          expect(selectEventHandler).toBeCalledTimes(1);
+        });
       });
 
       it('does not dispatch "selectionChanged" event on Arrowkeys when default is prevented', () => {

--- a/test-app/.eslintrc.js
+++ b/test-app/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     'no-unused-expressions': 'warn',
     'no-undef': 'warn',
     'no-param-reassign': 'warn',
-    'no-plusplus': 'warn'
+    'no-plusplus': 'warn',
   },
   extends: ['airbnb-base', 'prettier', 'prettier/prettier'],
   globals: {

--- a/test-app/babel.config.js
+++ b/test-app/babel.config.js
@@ -1,7 +1,7 @@
 module.exports = function babelConfig(api) {
   return {
     presets: [
-      ['@babel/preset-env', {modules: api.env(['test']) ? 'auto' : false}]
+      ['@babel/preset-env', { modules: api.env(['test']) ? 'auto' : false }],
     ],
   };
 };

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -41,7 +41,7 @@
     },
     "..": {
       "name": "@curriculumassociates/createjs-accessibility",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.14.183",

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -41,7 +41,7 @@
     },
     "..": {
       "name": "@curriculumassociates/createjs-accessibility",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.14.183",
@@ -52,6 +52,7 @@
       "devDependencies": {
         "@babel/core": "^7.18.10",
         "@babel/preset-env": "^7.20.2",
+        "@babel/preset-typescript": "^7.18.6",
         "@types/createjs": "0.0.29",
         "@types/eslint": "^8.4.5",
         "@types/jest": "^27.5.2",
@@ -12699,6 +12700,7 @@
       "requires": {
         "@babel/core": "^7.18.10",
         "@babel/preset-env": "^7.20.2",
+        "@babel/preset-typescript": "^7.18.6",
         "@types/createjs": "0.0.29",
         "@types/eslint": "^8.4.5",
         "@types/jest": "^27.5.2",

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -41,7 +41,7 @@
     },
     "..": {
       "name": "@curriculumassociates/createjs-accessibility",
-      "version": "1.5.1",
+      "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.14.183",

--- a/test-app/src/widgets/FormatText.js
+++ b/test-app/src/widgets/FormatText.js
@@ -103,7 +103,7 @@ export default class FormatText extends createjs.Container {
 
       case ROLES.FORMAT_TEXT_SMALL:
         this.label.font = 'smaller';
-        this.label.y += this.getTextHeight(this.label) * 0.5
+        this.label.y += this.getTextHeight(this.label) * 0.5;
         break;
 
       case ROLES.FORMAT_TEXT_SUBSCRIPT:

--- a/test-app/webpack.config.js
+++ b/test-app/webpack.config.js
@@ -32,7 +32,8 @@ const config = {
             loader: 'babel-loader',
             options: {
               presets: [
-                ['@babel/preset-env',
+                [
+                  '@babel/preset-env',
                   {
                     modules: false,
                     targets: {
@@ -42,7 +43,7 @@ const config = {
                       firefox: '79',
                       safari: '13.1.3',
                     },
-                  }
+                  },
                 ],
               ],
             },


### PR DESCRIPTION
- Added an `onInput` event listener in SingleLineTextBox and MultiLineTextBox so that, after every character is entered or deleted we call the `onChange` event listener so that change event is dispatched. Also, call `onSelect` event listener to update the cursor position.
- Added an `onKeyUp` event listener in SingleLineTextBox and MultiLineTextBox so that, every time arrow keys are used to move the cursor around, we call the `onSelect` event listener to update the cursor position.
- Bumped a patch version
- Added unit tests for the new `onInput` and `onKeyUp` methods